### PR TITLE
Improve orchestration failure feedback and add checkpoint retries

### DIFF
--- a/application/single_app/agent_delegation_runtime.py
+++ b/application/single_app/agent_delegation_runtime.py
@@ -17,6 +17,7 @@ import uuid
 
 from agent_execution_context import (
     AgentDelegationError,
+    AgentDelegationTimeout,
     AgentExecutionCancelled,
     AgentExecutionFrame,
     DelegationBudget,
@@ -59,7 +60,7 @@ def _check_cancelled(frame):
     if frame.cancel_requested and frame.cancel_requested():
         raise AgentExecutionCancelled("Agent execution was cancelled. Already submitted remote effects may continue.")
     if frame.deadline is not None and time.monotonic() >= frame.deadline:
-        raise AgentDelegationError("The delegated agent call timed out.")
+        raise AgentDelegationTimeout("The delegated agent call timed out.")
 
 
 async def await_agent_operation(awaitable, frame):
@@ -71,7 +72,7 @@ async def await_agent_operation(awaitable, frame):
             frame.budget.raise_authentication_requirement(frame.identity)
             remaining = frame.deadline - time.monotonic() if frame.deadline is not None else None
             if remaining is not None and remaining <= 0:
-                raise AgentDelegationError("The delegated agent call timed out.")
+                raise AgentDelegationTimeout("The delegated agent call timed out.")
             done, _ = await asyncio.wait(
                 {operation},
                 timeout=min(CANCELLATION_POLL_SECONDS, remaining) if remaining is not None else CANCELLATION_POLL_SECONDS,

--- a/application/single_app/agent_execution_context.py
+++ b/application/single_app/agent_execution_context.py
@@ -18,6 +18,10 @@ class AgentExecutionCancelled(AgentDelegationError):
     """The invoking turn was stopped; remote effects are not rolled back."""
 
 
+class AgentDelegationTimeout(AgentDelegationError, TimeoutError):
+    """A measured delegation deadline, distinct from explicit user cancellation."""
+
+
 @dataclass
 class DelegationBudget:
     """One lock-protected budget shared by descendants, siblings and retries."""

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.104"
+VERSION = "0.261.105"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_mixed_source_orchestration.py
+++ b/application/single_app/functions_mixed_source_orchestration.py
@@ -700,6 +700,7 @@ def _build_authorized_manifest_entry(document_id, user_id, document_context):
         "public_workspace_id": public_workspace_id,
         "conversation_id": conversation_id,
         "source_version": source_version,
+        "source_revision": document_item.get("_etag") or document_item.get("updated_at") or document_item.get("last_updated"),
         "storage_locator": storage_locator,
         "authorization_status": AUTHORIZATION_STATUS_AUTHORIZED,
     }

--- a/application/single_app/functions_orchestration_adapters.py
+++ b/application/single_app/functions_orchestration_adapters.py
@@ -89,6 +89,9 @@ from functions_orchestration_schema import (
     STEP_STATUS_COMPLETED,
     STEP_STATUS_FAILED,
     build_step_result,
+    build_failure,
+    failure_from_exception,
+    safe_failure,
 )
 
 _LOG_PREFIX = '[ORCHESTRATION_ADAPTERS]'
@@ -293,11 +296,12 @@ def _cancelled_result(summary):
 
 
 def _failed_result(summary, error, replan_hint=None):
+    failure = failure_from_exception(error) if isinstance(error, Exception) else build_failure()
     return build_step_result(
         status=STEP_STATUS_FAILED,
-        summary=summary,
-        error=error,
-        replan_hint=replan_hint,
+        summary=failure['message'],
+        error=failure['message'],
+        failure=failure,
     )
 
 
@@ -495,7 +499,7 @@ def run_document_search(step, context, *, settings, user_id, emit, cancel_reques
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Document search failed.', 'The selected sources could not be searched. Please retry.')
+        return _failed_result('Document search failed.', exc)
 
     results = list(results or [])
     document_ids = []
@@ -684,9 +688,11 @@ def run_document_analyze(step, context, *, settings, user_id, emit, cancel_reque
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Document analysis failed.', str(exc))
+        return _failed_result('Document analysis failed.', exc)
 
     envelopes = _analysis_envelopes(result, document_ids)
+    if any((envelope.get('coverage') or {}).get('failed_windows') for envelope in envelopes):
+        return _failed_result('Document analysis could not complete.', 'step_failed')
     reply = _text((result or {}).get('reply') or (result or {}).get('analysis_reply'))
     return build_step_result(
         status=STEP_STATUS_COMPLETED,
@@ -764,7 +770,7 @@ def run_document_compare(step, context, *, settings, user_id, emit, cancel_reque
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Document comparison failed.', str(exc))
+        return _failed_result('Document comparison failed.', exc)
 
     result = result if isinstance(result, dict) else {}
     reply = _text(result.get('reply') or result.get('analysis_reply'))
@@ -808,10 +814,10 @@ def run_document_compare(step, context, *, settings, user_id, emit, cancel_reque
 # --------------------------------------------------------------------------------------
 
 def _tabular_evidence_status(execution_state, reply, artifacts):
-    if reply or artifacts:
-        return EVIDENCE_STATUS_COMPLETED
     if execution_state in ('declined', 'failed', 'error'):
         return EVIDENCE_STATUS_FAILED
+    if reply or artifacts:
+        return EVIDENCE_STATUS_COMPLETED
     return EVIDENCE_STATUS_PARTIAL
 
 
@@ -880,7 +886,7 @@ def run_tabular_analyze(step, context, *, settings, user_id, emit, cancel_reques
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Tabular analysis failed.', str(exc))
+        return _failed_result('Tabular analysis failed.', exc)
 
     result = result if isinstance(result, dict) else {}
     reply = _text(result.get('analysis_reply') or result.get('reply'))
@@ -888,6 +894,8 @@ def run_tabular_analyze(step, context, *, settings, user_id, emit, cancel_reques
     artifacts = [generated] if isinstance(generated, dict) else []
     execution_state = _text(result.get('execution_state')).lower()
     envelope_status = _tabular_evidence_status(execution_state, reply, artifacts)
+    if envelope_status == EVIDENCE_STATUS_FAILED:
+        return _failed_result('Tabular analysis could not complete.', 'step_failed')
 
     envelopes = []
     for index, source in enumerate(tabular_sources):
@@ -964,7 +972,7 @@ def run_web_search(step, context, *, settings, user_id, emit, cancel_requested):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Web search failed.', str(exc))
+        return _failed_result('Web search failed.', exc)
 
     notes = [
         _text(message.get('content'))
@@ -1083,10 +1091,9 @@ def _finalize_source_review(
             citations=citations,
         )
 
-    reason = _text(result.get('skipped_reason'))
     return build_step_result(
         status=STEP_STATUS_COMPLETED,
-        summary=empty_summary + (f' ({reason})' if reason else ''),
+        summary=empty_summary,
         notes=notes,
         citations=citations,
         replan_hint=empty_replan_hint,
@@ -1135,7 +1142,7 @@ def run_url_fetch(step, context, *, settings, user_id, emit, cancel_requested):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('Reading linked pages is unavailable.', str(exc))
+        return _failed_result('Reading linked pages is unavailable.', exc)
 
     # Rewritten requests can contain model-generated links. Seed only the separately
     # authorized user-authored URLs, including any referenced historical user message.
@@ -1175,7 +1182,7 @@ def run_url_fetch(step, context, *, settings, user_id, emit, cancel_requested):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('The linked pages could not be read.', str(exc))
+        return _failed_result('The linked pages could not be read.', exc)
 
     return _finalize_source_review(
         result,
@@ -1508,17 +1515,19 @@ def _agent_citations(plugin_logger, user_id, conversation_id, seen_before, root_
             build_agent_citation_tool_label,
             make_json_serializable,
         )
+        from semantic_kernel_plugins.plugin_invocation_logger import sanitize_plugin_invocation_value
     except Exception:
         build_agent_citation_tool_label = None
         make_json_serializable = None
+        sanitize_plugin_invocation_value = None
 
     def _serialize(value):
-        if make_json_serializable:
+        if make_json_serializable and sanitize_plugin_invocation_value:
             try:
-                return make_json_serializable(value)
+                return sanitize_plugin_invocation_value(make_json_serializable(value), max_string_length=None)
             except Exception:
                 pass
-        return _text(value) if value is not None else None
+        return None
 
     citations = []
     for inv in invocations or ():
@@ -1547,11 +1556,11 @@ def _agent_citations(plugin_logger, user_id, conversation_id, seen_before, root_
             'function_name': function_name,
             'plugin_name': plugin_name,
             'function_arguments': _serialize(parameters),
-            'function_result': _serialize(inv_result),
+            'function_result': _serialize(inv_result) if getattr(inv, 'success', None) is not False else None,
             'duration_ms': getattr(inv, 'duration_ms', None),
             'timestamp': timestamp_str,
             'success': getattr(inv, 'success', None),
-            'error_message': _serialize(getattr(inv, 'error_message', None)),
+            'error_message': build_failure()['message'] if getattr(inv, 'success', None) is False else None,
             'user_id': getattr(inv, 'user_id', None),
             'delegation': getattr(inv, 'provenance', None),
         })
@@ -1597,10 +1606,7 @@ def run_action_invoke(step, context, *, settings, user_id, emit, cancel_requeste
             extra={'action_ref': action_ref, 'step_id': (step or {}).get('step_id'),
                    'error_type': type(exc).__name__},
         )
-        return _failed_result(
-            'The action could not complete.',
-            'Check action access, configuration, enabled functions, and model availability.',
-        )
+        return _failed_result('The action could not complete.', exc)
     citations = _agent_citations(
         None, user_id, _ctx(context, 'conversation_id'), set(),
         root_id=result['root_id'], scoped_invocations=result['invocations'],
@@ -1663,7 +1669,7 @@ def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('The agent could not be resolved.', str(exc))
+        return _failed_result('The agent could not be resolved.', exc)
 
     if _is_cancelled(cancel_requested):
         return _cancelled_result('Cancelled before invoking the agent.')
@@ -1694,12 +1700,7 @@ def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested
         except Exception as exc:
             log_event('[AGENT_DELEGATION] Orchestration agent execution failed.',
                       extra={'error_type': type(exc).__name__, 'step_id': (step or {}).get('step_id')})
-            safe_error = (
-                'The called agent requires sign-in or consent for Foundry.'
-                if type(exc).__name__ == 'FoundryAgentUserAuthenticationRequired'
-                else 'The selected agent could not complete the task.'
-            )
-            return _failed_result('The agent invocation failed.', safe_error)
+            return _failed_result('The agent invocation failed.', exc)
         new_records = [record for record in budget.snapshot() if record['invocation_id'] not in prior_ids]
         usage = _ctx(context, 'token_usage', None)
         if isinstance(usage, dict):
@@ -1754,7 +1755,7 @@ def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('The agent could not be loaded.', str(exc))
+        return _failed_result('The agent could not be loaded.', exc)
 
     if not kernel or selected_agent is None:
         return _failed_result(
@@ -1780,7 +1781,7 @@ def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested
     try:
         reply = _invoke_agent_sync(selected_agent, task)
     except _AgentEventLoopError as exc:
-        return _failed_result('The agent could not run in this context.', str(exc))
+        return _failed_result('The agent could not run in this context.', exc)
     except Exception as exc:
         log_event(
             f'{_LOG_PREFIX} agent_invoke failed during invocation: {exc}',
@@ -1788,7 +1789,7 @@ def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('The agent invocation failed.', str(exc))
+        return _failed_result('The agent invocation failed.', exc)
 
     _record_agent_token_usage(context, kernel)
     citations = _agent_citations(plugin_logger, user_id, conversation_id, seen_before)
@@ -1875,13 +1876,20 @@ def run_respond(step, context, *, settings, user_id, emit, cancel_requested):
             f'{_LOG_PREFIX} Saved memory is unavailable for synthesis.',
             level=logging.WARNING, extra={'reason': exc.code},
         )
-        return _failed_result(exc.message, exc.code)
+        failure = build_failure('context_unavailable')
+        return build_step_result(status=STEP_STATUS_FAILED, failure=failure, summary=failure['message'], error=failure['message'])
     _emit(emit, _progress(step, CAPABILITY_RESPOND, 'Writing the answer'))
 
     user_message = _text(_ctx(context, 'user_message', ''))
     instruction = _text(arguments.get('instruction') or arguments.get('prompt'))
     evidence = [envelope for envelope in (_ctx(context, 'evidence', []) or []) if isinstance(envelope, dict)]
     notes = list(_ctx(context, 'notes', []) or [])
+    failures = [safe_failure(value) for value in (_ctx(context, 'failures', []) or [])]
+    if failures:
+        notes.append(
+            'Application-recorded incomplete work (explain these limitations; do not claim full success):\n'
+            + json.dumps(failures, ensure_ascii=False)
+        )
     citations = list(_ctx(context, 'citations', []) or [])
     citations.extend(memory.get('citations') or [])
 
@@ -1940,7 +1948,11 @@ def run_respond(step, context, *, settings, user_id, emit, cancel_requested):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
-        return _failed_result('The answer could not be written.', str(exc))
+        failure = build_failure('context_unavailable') if isinstance(exc, OrchestrationMemoryError) else failure_from_exception(exc, answering=True)
+        return build_step_result(
+            status=STEP_STATUS_FAILED, failure=failure,
+            summary=failure['message'], error=failure['message'],
+        )
 
     reply = reply or _EMPTY_ANSWER
     return build_step_result(

--- a/application/single_app/functions_orchestration_checkpoints.py
+++ b/application/single_app/functions_orchestration_checkpoints.py
@@ -1,0 +1,344 @@
+# functions_orchestration_checkpoints.py
+"""Private, immutable step-boundary checkpoints in the run-steps partition.
+
+Version: 0.261.105
+The lifecycle row fences every batch, including uncommitted chunks. It survives
+cleanup, so an old worker cannot recreate payloads after conversation deletion.
+"""
+
+import base64
+import hashlib
+import json
+import math
+import uuid
+from copy import deepcopy
+
+from azure.core import MatchConditions
+from azure.cosmos import exceptions
+
+from functions_orchestration_schema import build_failure
+
+
+CHECKPOINT_VERSION = 1
+CHUNK_BYTES = 128 * 1024
+MAX_DOCUMENT_BYTES = 256 * 1024
+MAX_CHECKPOINT_BYTES = 8 * 1024 * 1024
+MAX_CHUNKS = 64
+LIFECYCLE_ID = 'checkpoint:lifecycle'
+STATE_FIELDS = (
+    'evidence', 'citations', 'artifacts', 'notes', 'documents_touched',
+    'step_documents', 'execution_manifest', 'source_manifest',
+)
+INPUT_FIELDS = (
+    'user_message', 'user_message_id', 'resolved_message', 'answered_questions',
+    'elicitation_references', 'selected_document_ids', 'original_seeds',
+    'conversation_context', 'context_message_ids', 'allowed_user_urls',
+    'chat_type', 'selection_mode', 'doc_scope', 'tags', 'document_filter_mode',
+    'active_group_ids', 'active_group_id', 'active_public_workspace_ids',
+    'gpt_model',
+)
+
+
+class CheckpointError(RuntimeError):
+    def __init__(self, code='checkpoint_unavailable'):
+        self.failure = build_failure(code)
+        self.code = self.failure['code']
+        super().__init__(self.failure['message'])
+
+
+def _check_json(value, depth=0):
+    if depth > 64:
+        raise CheckpointError('checkpoint_invalid')
+    if value is None or type(value) in (str, bool, int):
+        return
+    if type(value) is float and math.isfinite(value):
+        return
+    if isinstance(value, list):
+        for item in value:
+            _check_json(item, depth + 1)
+        return
+    if isinstance(value, dict) and all(isinstance(key, str) for key in value):
+        for item in value.values():
+            _check_json(item, depth + 1)
+        return
+    raise CheckpointError('checkpoint_invalid')
+
+
+def json_bytes(value):
+    _check_json(value)
+    try:
+        return json.dumps(value, sort_keys=True, ensure_ascii=False, separators=(',', ':'), allow_nan=False).encode('utf-8')
+    except (ValueError, UnicodeError, TypeError) as exc:
+        raise CheckpointError('checkpoint_invalid') from exc
+
+
+def fingerprint(value):
+    return hashlib.sha256(json_bytes(value)).hexdigest()
+
+
+def effective_plan(plan):
+    return [
+        {key: deepcopy(step.get(key)) for key in (
+            'step_id', 'capability_id', 'arguments', 'depends_on', 'enabled', 'optional',
+        )}
+        for step in plan.get('steps') or []
+    ]
+
+
+def context_state(context):
+    state = {key: deepcopy(getattr(context, key, None)) for key in STATE_FIELDS}
+    json_bytes(state)
+    return state
+
+
+def context_binding(context, plan, settings):
+    """Hash runtime bindings; never persist identity, credentials or memory prompts."""
+    model = getattr(context, 'model_context', None) or {}
+    return fingerprint({
+        'plan': effective_plan(plan),
+        'inputs': {key: getattr(context, key, None) for key in INPUT_FIELDS},
+        'model': {key: model.get(key) for key in ('model_id', 'endpoint_id', 'provider', 'model_deployment')},
+        'memory_digest': fingerprint(getattr(context, 'memory_context', {}) or {}),
+        'agent_catalog_digest': fingerprint(getattr(context, 'agent_catalog', []) or []),
+        'action_catalog_digest': fingerprint(getattr(context, 'action_catalog', []) or []),
+        'settings_digest': fingerprint(settings),
+    })
+
+
+def step_input_fingerprint(step, context, binding):
+    # All accumulated context matters: action_invoke consumes earlier_findings even
+    # without a declared dependency. Usage is attribution, not an adapter input.
+    return fingerprint({'binding': binding, 'step': effective_plan({'steps': [step]})[0], 'context': context_state(context)})
+
+
+def restore_context(context, payload):
+    state = payload.get('state')
+    if not isinstance(state, dict) or set(state) != set(STATE_FIELDS):
+        raise CheckpointError('checkpoint_invalid')
+    json_bytes(state)
+    for key in STATE_FIELDS:
+        setattr(context, key, deepcopy(state[key]))
+
+
+class CheckpointStore:
+    def __init__(self, container, *, run_id, user_id, conversation_id, turn_id, authorize, token=None):
+        self.container = container
+        self.identity = {
+            'run_id': run_id, 'user_id': user_id, 'conversation_id': conversation_id,
+            'turn_id': turn_id, 'schema_version': CHECKPOINT_VERSION,
+        }
+        self.authorize = authorize
+        self.token = token
+
+    def _authorized(self):
+        if not callable(self.authorize) or self.authorize() is False:
+            raise CheckpointError('context_unavailable')
+
+    def _verify(self, document):
+        if not isinstance(document, dict) or any(document.get(key) != value for key, value in self.identity.items()):
+            raise CheckpointError('checkpoint_invalid')
+        return document
+
+    def _read(self, item_id):
+        self._authorized()
+        try:
+            return self._verify(self.container.read_item(item=item_id, partition_key=self.identity['run_id']))
+        except CheckpointError:
+            raise
+        except Exception as exc:
+            raise CheckpointError() from exc
+
+    def initialize(self):
+        self._authorized()
+        if not self.token:
+            raise CheckpointError('ownership_lost')
+        document = {**self.identity, 'id': LIFECYCLE_ID, 'record_type': 'checkpoint_lifecycle', 'token': self.token, 'deleted': False}
+        try:
+            self.container.create_item(body=document)
+        except exceptions.CosmosResourceExistsError:
+            existing = self._read(LIFECYCLE_ID)
+            if existing.get('deleted') or existing.get('token') != self.token:
+                raise CheckpointError('ownership_lost') from None
+        except Exception as exc:
+            raise CheckpointError() from exc
+
+    def _write(self, document, *, immutable=True):
+        self._authorized()
+        document = {**document, **self.identity}
+        if len(json_bytes(document)) > MAX_DOCUMENT_BYTES:
+            raise CheckpointError('checkpoint_invalid')
+        for _ in range(8):
+            guard = self._read(LIFECYCLE_ID)
+            if guard.get('deleted') or guard.get('token') != self.token or not self.token:
+                raise CheckpointError('ownership_lost')
+            replacement = {key: value for key, value in guard.items() if not key.startswith('_')}
+            replacement['write_id'] = uuid.uuid4().hex
+            operations = [
+                ('replace', (LIFECYCLE_ID, replacement), {'if_match_etag': guard['_etag']}),
+                ('create' if immutable else 'upsert', (document,)),
+            ]
+            try:
+                self.container.execute_item_batch(batch_operations=operations, partition_key=self.identity['run_id'])
+                return
+            except (exceptions.CosmosBatchOperationError, exceptions.CosmosHttpResponseError) as exc:
+                if exc.status_code == 412:
+                    continue
+                if immutable and exc.status_code == 409:
+                    saved = self._read(document['id'])
+                    if all(saved.get(key) == value for key, value in document.items()):
+                        return
+                raise CheckpointError() from exc
+            except Exception as exc:
+                raise CheckpointError() from exc
+        raise CheckpointError()
+
+    def save_step(self, record):
+        self._write({
+            **deepcopy(record), 'id': f"{self.identity['run_id']}:{record['step_id']}",
+            'record_type': 'step',
+        }, immutable=False)
+
+    def commit(self, step, result, context, *, input_fingerprint, binding, provenance=None, artifact_versions=None):
+        if result.get('status') != 'completed':
+            raise CheckpointError('checkpoint_invalid')
+        payload = {
+            'schema_version': CHECKPOINT_VERSION, 'binding': binding,
+            'input_fingerprint': input_fingerprint, 'step_id': step['step_id'],
+            'result': deepcopy(result), 'state': context_state(context),
+            'usage': deepcopy(getattr(context, 'step_token_usage', {}) or {}),
+            'provenance': provenance or {'run_id': self.identity['run_id'], 'step_id': step['step_id']},
+            'artifact_versions': artifact_versions or {},
+        }
+        raw = json_bytes(payload)
+        if not raw or len(raw) > MAX_CHECKPOINT_BYTES:
+            raise CheckpointError('checkpoint_invalid')
+        digest = hashlib.sha256(raw).hexdigest()
+        prefix = f"checkpoint:{fingerprint(step['step_id'])}"
+        chunks = [raw[offset:offset + CHUNK_BYTES] for offset in range(0, len(raw), CHUNK_BYTES)]
+        if len(chunks) > MAX_CHUNKS:
+            raise CheckpointError('checkpoint_invalid')
+        for index, data in enumerate(chunks):
+            self._write({
+                'id': f'{prefix}:{digest}:{index}', 'record_type': 'checkpoint_chunk',
+                'step_id': step['step_id'], 'index': index, 'digest': digest,
+                'data': base64.b64encode(data).decode('ascii'),
+            })
+        manifest = {
+            'id': prefix, 'record_type': 'checkpoint_manifest', 'step_id': step['step_id'],
+            'digest': digest, 'bytes': len(raw), 'chunks': len(chunks),
+            'binding': binding, 'input_fingerprint': input_fingerprint,
+        }
+        self._write(manifest)
+        return payload
+
+    def load(self, step_id):
+        guard = self._read(LIFECYCLE_ID)
+        if guard.get('deleted'):
+            raise CheckpointError('context_unavailable')
+        prefix = f'checkpoint:{fingerprint(step_id)}'
+        manifest = self._read(prefix)
+        count, size, digest = manifest.get('chunks'), manifest.get('bytes'), manifest.get('digest')
+        if (
+            manifest.get('record_type') != 'checkpoint_manifest' or manifest.get('step_id') != step_id
+            or type(count) is not int or not 1 <= count <= MAX_CHUNKS
+            or type(size) is not int or not 1 <= size <= MAX_CHECKPOINT_BYTES
+            or not isinstance(digest, str) or len(digest) != 64
+        ):
+            raise CheckpointError('checkpoint_invalid')
+        parts = []
+        for index in range(count):
+            chunk = self._read(f'{prefix}:{digest}:{index}')
+            if (
+                chunk.get('record_type') != 'checkpoint_chunk' or chunk.get('index') != index
+                or chunk.get('step_id') != step_id or chunk.get('digest') != digest
+                or len(json_bytes(chunk)) > MAX_DOCUMENT_BYTES
+            ):
+                raise CheckpointError('checkpoint_invalid')
+            try:
+                part = base64.b64decode(chunk['data'], validate=True)
+            except (KeyError, ValueError, TypeError) as exc:
+                raise CheckpointError('checkpoint_invalid') from exc
+            if not part or len(part) > CHUNK_BYTES:
+                raise CheckpointError('checkpoint_invalid')
+            parts.append(part)
+        raw = b''.join(parts)
+        if len(raw) != size or hashlib.sha256(raw).hexdigest() != digest:
+            raise CheckpointError('checkpoint_invalid')
+        try:
+            payload = json.loads(raw)
+        except (ValueError, UnicodeError) as exc:
+            raise CheckpointError('checkpoint_invalid') from exc
+        if (
+            payload.get('schema_version') != CHECKPOINT_VERSION or payload.get('step_id') != step_id
+            or payload.get('binding') != manifest.get('binding')
+            or payload.get('input_fingerprint') != manifest.get('input_fingerprint')
+            or (payload.get('result') or {}).get('status') != 'completed'
+        ):
+            raise CheckpointError('checkpoint_invalid')
+        self._authorized()
+        return payload
+
+    def has_manifest(self, step_id):
+        self._authorized()
+        try:
+            self.container.read_item(
+                item=f'checkpoint:{fingerprint(step_id)}', partition_key=self.identity['run_id'],
+            )
+            return True
+        except exceptions.CosmosResourceNotFoundError:
+            return False
+        except Exception as exc:
+            raise CheckpointError('checkpoint_unavailable') from exc
+
+    def fence(self, *, deleted=False, allow_missing=False):
+        """Revoke the partition writer before recovery publication or cleanup."""
+        for _ in range(8):
+            self._authorized()
+            try:
+                guard = self._verify(self.container.read_item(
+                    item=LIFECYCLE_ID, partition_key=self.identity['run_id'],
+                ))
+            except exceptions.CosmosResourceNotFoundError:
+                if not allow_missing:
+                    raise CheckpointError('checkpoint_unavailable') from None
+                try:
+                    self.container.create_item(body={
+                        **self.identity, 'id': LIFECYCLE_ID, 'record_type': 'checkpoint_lifecycle',
+                        'token': None, 'deleted': deleted,
+                    })
+                    return
+                except exceptions.CosmosResourceExistsError:
+                    continue
+                except Exception as exc:
+                    raise CheckpointError('checkpoint_unavailable') from exc
+            except CheckpointError:
+                raise
+            except Exception as exc:
+                raise CheckpointError('checkpoint_unavailable') from exc
+            replacement = {key: value for key, value in guard.items() if not key.startswith('_')}
+            replacement.update({'token': None, 'deleted': deleted or guard.get('deleted', False)})
+            try:
+                self.container.replace_item(
+                    item=LIFECYCLE_ID, body=replacement, etag=guard['_etag'],
+                    match_condition=MatchConditions.IfNotModified,
+                )
+                return
+            except exceptions.CosmosAccessConditionFailedError:
+                continue
+        raise CheckpointError()
+
+    def delete_payloads(self):
+        self.fence(deleted=True)
+        rows = list(self.container.query_items(
+            query='SELECT * FROM c WHERE c.run_id = @partition_run',
+            parameters=[{'name': '@partition_run', 'value': self.identity['run_id']}],
+            partition_key=self.identity['run_id'],
+        ))
+        for row in rows:
+            if row.get('id') == LIFECYCLE_ID:
+                continue
+            self._verify(row)
+            self.container.delete_item(
+                item=row['id'], partition_key=self.identity['run_id'],
+                etag=row['_etag'], match_condition=MatchConditions.IfNotModified,
+            )

--- a/application/single_app/functions_orchestration_events.py
+++ b/application/single_app/functions_orchestration_events.py
@@ -311,7 +311,7 @@ def build_elicitation_event(elicitation):
     })
 
 
-def build_step_event(step_id, status, summary='', step_index=None, capability_id=None):
+def build_step_event(step_id, status, summary='', step_index=None, capability_id=None, **execution):
     """A named step changed state, so the plan card can tick exactly that row."""
     payload = {
         'type': EVENT_TYPE_STEP,
@@ -323,6 +323,11 @@ def build_step_event(step_id, status, summary='', step_index=None, capability_id
         payload['step_index'] = step_index
     if capability_id:
         payload['capability_id'] = capability_id
+    payload.update({
+        key: execution[key] for key in (
+            'failure', 'reused', 'reused_from_run_id', 'checkpoint_available',
+        ) if key in execution
+    })
     return serialize_sse(payload)
 
 
@@ -357,6 +362,15 @@ def build_run_done_event(
     requested_reasoning_effort=None,
     reasoning_mode=None,
     reasoning_adjustments=None,
+    outcome=None,
+    turn_id=None,
+    attempt_index=1,
+    retry_of_run_id=None,
+    failure=None,
+    failures=None,
+    recovery=None,
+    message_saved=True,
+    finalization_status=None,
 ):
     """Terminal frame of the run endpoint.
 
@@ -381,6 +395,15 @@ def build_run_done_event(
         'generated_artifacts': list(artifacts or ()),
         'orchestration': plan_summary or {},
         'status': status,
+        'outcome': outcome or status,
+        'turn_id': turn_id,
+        'attempt_index': attempt_index,
+        'retry_of_run_id': retry_of_run_id,
+        'failure': failure,
+        'failures': list(failures or []),
+        'recovery': recovery,
+        'message_saved': message_saved,
+        **({'finalization_status': finalization_status} if finalization_status else {}),
         'reasoning_adjustments': list(reasoning_adjustments or ()),
         **{
             key: value for key, value in {

--- a/application/single_app/functions_orchestration_executor.py
+++ b/application/single_app/functions_orchestration_executor.py
@@ -68,6 +68,13 @@ from functions_orchestration_schema import (
     STEP_STATUS_RUNNING,
     STEP_STATUS_SKIPPED,
     build_step_result,
+    build_failure,
+    safe_failure,
+    failure_from_exception,
+    failure_explanation,
+)
+from functions_orchestration_checkpoints import (
+    CheckpointError, restore_context, step_input_fingerprint,
 )
 
 _LOG_PREFIX = '[ORCHESTRATION_EXECUTOR]'
@@ -136,8 +143,8 @@ def _make_cancel_probe(cancel_requested):
     def _probe():
         try:
             return bool(cancel_requested())
-        except Exception:
-            return False
+        except Exception as exc:
+            raise CheckpointError('ownership_lost') from exc
 
     return _probe
 
@@ -168,6 +175,7 @@ class RunContext:
         conversation_id=None,
         user_id=None,
         turn_index=0,
+        attempt_index=1,
         invoke_prompt=None,
         planner_client=None,
         planner_deployment=None,
@@ -211,6 +219,7 @@ class RunContext:
         self.conversation_id = conversation_id
         self.user_id = user_id
         self.turn_index = turn_index
+        self.attempt_index = attempt_index
 
         self.invoke_prompt = invoke_prompt
         self.planner_client = planner_client
@@ -287,6 +296,8 @@ class RunContext:
         self.artifacts = []
         self.notes = []
         self.token_usage = {}
+        self.failures = []
+        self.step_token_usage = {}
 
         # Documents any step produced evidence for, in first-seen order.
         self.documents_touched = []
@@ -437,7 +448,7 @@ def _run_single_step(step, context, settings, user_id, emit, step_cancel, get_ad
         return build_step_result(
             status=STEP_STATUS_FAILED,
             summary='The step raised an unexpected error.',
-            error=str(exc),
+            failure=failure_from_exception(exc, answering=capability_id == CAPABILITY_RESPOND),
         )
 
     if not isinstance(result, dict) or 'status' not in result:
@@ -480,6 +491,11 @@ def _step_record(context, step, index, status, result, started_at, completed_at,
         'arguments': step.get('arguments') if isinstance(step.get('arguments'), dict) else {},
         'duration_ms': duration_ms,
         'replan_hint': result.get('replan_hint'),
+        'failure': result.get('failure'),
+        'checkpoint_available': False,
+        'reused': False,
+        'reused_from_run_id': None,
+        'effects_uncertain': status == STEP_STATUS_RUNNING and step.get('capability_id') in ('agent_invoke', 'action_invoke'),
     }
 
 
@@ -489,13 +505,12 @@ def _persist(persist, record_type, record):
     try:
         persist(record_type, record)
     except Exception as exc:
-        # Persistence is a side effect of running the plan, not a condition for it; a failed
-        # write is logged and the run continues rather than losing the answer.
         log_event(
             f'{_LOG_PREFIX} Failed to persist {record_type} record: {exc}',
             level=logging.ERROR,
             exceptionTraceback=True,
         )
+        raise CheckpointError() from exc
 
 
 # --------------------------------------------------------------------------------------
@@ -534,6 +549,8 @@ def _reauthorize_before_finalization(context, settings, user_id, cancel_requeste
     except MixedSourceCancellationError:
         raise
     except Exception as exc:
+        if getattr(context, 'durable_checkpoints', False):
+            raise ElicitationContextError('Sources could not be reauthorized.') from exc
         if context.elicitation_references:
             log_event(
                 f'{_LOG_PREFIX} Accepted source re-authorization failed.',
@@ -548,6 +565,8 @@ def _reauthorize_before_finalization(context, settings, user_id, cancel_requeste
         fresh_manifest = None
 
     if not fresh_manifest:
+        if getattr(context, 'durable_checkpoints', False):
+            raise ElicitationContextError('Sources could not be reauthorized.')
         if context.elicitation_references:
             raise ElicitationContextError('Accepted answer sources could not be rechecked. Please retry the run.')
         # The resolver could not run (no resolver wired, or it errored). The evidence was
@@ -576,9 +595,15 @@ def _reauthorize_before_finalization(context, settings, user_id, cancel_requeste
         raise ElicitationContextError('An accepted answer source is no longer available. Please update the answer.')
 
     if dropped:
+        if getattr(context, 'durable_checkpoints', False):
+            raise ElicitationContextError('A saved source is no longer available.')
         context.evidence = [
             envelope for envelope in evidence
             if _text(envelope.get('document_id')) not in dropped
+        ]
+        context.citations = [
+            citation for citation in context.citations or []
+            if not isinstance(citation, dict) or _text(citation.get('document_id')) not in dropped
         ]
         # Rebuild documents_touched to match the surviving evidence, so the run record does
         # not claim to have used a document whose evidence was just dropped.
@@ -621,6 +646,7 @@ def execute_plan(
     cancel_requested=None,
     persist=None,
     get_adapter=None,
+    checkpoints=None,
 ):
     """Run a validated plan to an answer and return the run result.
 
@@ -658,12 +684,13 @@ def execute_plan(
         )
 
     def unavailable_context_result():
+        failure = build_failure('context_unavailable')
         result = {
             'run_id': context.run_id,
             'status': PLAN_STATUS_FAILED,
             'completed_at': _now_iso(),
-            'message': '',
-            'error': 'Accepted answer context is no longer available. Please update the answer or retry.',
+            'message': failure_explanation([failure]),
+            'error': failure['message'], 'failure': failure, 'failures': [failure], 'outcome': 'failed',
             'evidence': [], 'citations': [], 'artifacts': [],
             'reauthorization': {'checked': True, 'reason': 'elicitation_context_unavailable'},
         }
@@ -710,6 +737,16 @@ def execute_plan(
     terminal_result = None
     reauthorization = {'checked': False, 'reason': 'not_reached', 'dropped_document_ids': []}
     first_error = None
+    if checkpoints is not None:
+        context.durable_checkpoints = True
+        checkpoints = checkpoints(context) if callable(checkpoints) else checkpoints
+        checkpoints.initialize()
+
+    def persist_step(record):
+        if checkpoints is not None:
+            checkpoints.save_step(record)
+        else:
+            _persist(persist, 'step', record)
 
     for index, step in enumerate(ordered_steps):
         step_id = step.get('step_id')
@@ -722,7 +759,10 @@ def execute_plan(
             statuses[step_id] = STEP_STATUS_CANCELLED
             record = _step_record(context, step, index, STEP_STATUS_CANCELLED, None, None, None, 0)
             step_records.append(record)
-            _persist(persist, 'step', record)
+            record['failure'] = build_failure('user_cancelled', step_id=step_id, capability_id=step.get('capability_id'))
+            if not context.failures:
+                context.failures.append(record['failure'])
+            persist_step(record)
             _emit(emit, {'type': 'step', 'phase': STEP_STATUS_CANCELLED, 'step_id': step_id,
                          'capability_id': step.get('capability_id'), 'step_index': index,
                          'completed': index + 1, 'total': total_units})
@@ -743,7 +783,7 @@ def execute_plan(
                 statuses[step_id] = STEP_STATUS_CANCELLED
                 record = _step_record(context, step, index, STEP_STATUS_CANCELLED, None, None, None, 0)
                 step_records.append(record)
-                _persist(persist, 'step', record)
+                persist_step(record)
                 continue
             except ElicitationContextError:
                 return unavailable_context_result()
@@ -754,7 +794,7 @@ def execute_plan(
             result = build_step_result(status=STEP_STATUS_SKIPPED, summary='Step is disabled.')
             record = _step_record(context, step, index, STEP_STATUS_SKIPPED, result, None, None, 0)
             step_records.append(record)
-            _persist(persist, 'step', record)
+            persist_step(record)
             _emit(emit, {'type': 'step', 'phase': STEP_STATUS_SKIPPED, 'step_id': step_id,
                          'capability_id': step.get('capability_id'), 'step_index': index,
                          'completed': index + 1, 'total': total_units})
@@ -765,13 +805,15 @@ def execute_plan(
         # than to nothing.
         over_total_time = bool(total_deadline and time.monotonic() > total_deadline)
         over_step_budget = (not is_terminal) and executed_non_terminal >= max_steps
-        if not is_terminal and (over_total_time or over_step_budget):
+        if over_total_time or over_step_budget:
             statuses[step_id] = STEP_STATUS_SKIPPED
             reason = 'the time budget was exhausted' if over_total_time else 'the step budget was reached'
             result = build_step_result(status=STEP_STATUS_SKIPPED, summary=f'Skipped because {reason}.')
+            result['failure'] = build_failure('run_timeout' if over_total_time else 'step_budget', step_id=step_id, capability_id=step.get('capability_id'))
+            context.failures.append(result['failure'])
             record = _step_record(context, step, index, STEP_STATUS_SKIPPED, result, None, None, 0)
             step_records.append(record)
-            _persist(persist, 'step', record)
+            persist_step(record)
             if not budget_note_emitted:
                 context.notes.append(f'Some steps were skipped because {reason}.')
                 budget_note_emitted = True
@@ -790,34 +832,99 @@ def execute_plan(
             )
             record = _step_record(context, step, index, STEP_STATUS_SKIPPED, result, None, None, 0)
             step_records.append(record)
-            _persist(persist, 'step', record)
+            persist_step(record)
             _emit(emit, {'type': 'step', 'phase': STEP_STATUS_SKIPPED, 'step_id': step_id,
                          'capability_id': step.get('capability_id'), 'step_index': index,
                          'completed': index + 1, 'total': total_units})
             continue
 
-        # Run it. The per-step deadline is folded into the cancel probe rather than enforced
-        # by killing a thread: adapters check cancellation at their own safe points, which is
-        # the only portable way to time-bound work that may hold external resources.
+        reused = checkpoints.before_step(step) if checkpoints is not None else None
+        input_fingerprint = (
+            step_input_fingerprint(step, context, checkpoints.binding) if checkpoints is not None else None
+        )
+        if reused:
+            restore_context(context, reused)
+            result = deepcopy(reused['result'])
+            context.step_token_usage = deepcopy(reused.get('usage') or {})
+            checkpoints.commit(step, result, input_fingerprint, reused=reused)
+            record = _step_record(context, step, index, STEP_STATUS_COMPLETED, result, None, _now_iso(), 0)
+            record.update({
+                'checkpoint_available': True, 'reused': True,
+                'reused_from_run_id': (reused.get('provenance') or {}).get('run_id'),
+                'summary': 'Reused saved result',
+                'token_usage': {}, 'reused_token_usage': deepcopy(reused.get('usage') or {}),
+            })
+            step_records.append(record)
+            statuses[step_id] = STEP_STATUS_COMPLETED
+            persist_step(record)
+            _emit(emit, {
+                'type': 'step', 'phase': STEP_STATUS_COMPLETED, **record,
+                'completed': index + 1, 'total': total_units,
+            })
+            continue
+
+        # Cooperative interruption retains its measured cause. A callback may stop
+        # blocked providers, but a deadline is never evidence of the user pressing Stop.
         step_deadline = time.monotonic() + step_timeout if step_timeout else None
+        control = {'reason': None}
 
         def _step_cancel(_step_deadline=step_deadline):
+            if control['reason']:
+                return True
             if cancel_probe():
+                control['reason'] = 'user_cancelled'
                 return True
             now = time.monotonic()
-            if _step_deadline and now > _step_deadline:
+            if total_deadline and now >= total_deadline:
+                control['reason'] = 'run_timeout'
                 return True
-            if total_deadline and now > total_deadline:
+            if _step_deadline and now >= _step_deadline:
+                control['reason'] = 'step_timeout'
                 return True
             return False
 
+        started_at = _now_iso()
+        running_record = _step_record(context, step, index, STEP_STATUS_RUNNING, None, started_at, None, 0)
+        persist_step(running_record)
         _emit(emit, {'type': 'step', 'phase': STEP_STATUS_RUNNING, 'step_id': step_id,
                      'capability_id': step.get('capability_id'), 'step_index': index,
                      'title': step.get('title'), 'completed': index, 'total': total_units})
 
-        started_at = _now_iso()
         started_monotonic = time.monotonic()
+        usage_before = deepcopy(context.token_usage)
+        prompt_usage_before = deepcopy(getattr(context, 'prompt_token_usage', {}) or {})
         result = _run_single_step(step, context, settings, user_id, emit, _step_cancel, get_adapter)
+        _step_cancel()
+        reason = control['reason']
+        if reason or result.get('status') in (STEP_STATUS_FAILED, STEP_STATUS_CANCELLED):
+            failure = build_failure(
+                reason or ('execution_interrupted' if result.get('status') == STEP_STATUS_CANCELLED else 'step_failed'),
+                step_id=step_id, capability_id=step.get('capability_id'),
+            ) if reason or not result.get('failure') else safe_failure(
+                result['failure'], step_id=step_id, capability_id=step.get('capability_id'),
+            )
+            # Failure details are not trusted data. No provider body, adapter error
+            # prose, partial diagnostic citations or stack trace reaches the answer.
+            result = build_step_result(
+                status=STEP_STATUS_CANCELLED if reason == 'user_cancelled' else STEP_STATUS_FAILED,
+                summary=failure['message'], error=failure['message'], failure=failure,
+            )
+            context.failures.append(failure)
+            log_event(
+                f'{_LOG_PREFIX} Step did not complete.',
+                extra={
+                    'run_id': context.run_id, 'step_id': step_id,
+                    'attempt_index': context.attempt_index, 'reason_code': failure['code'],
+                }, level=logging.WARNING,
+            )
+        context.step_token_usage = {
+            key: value - usage_before.get(key, 0)
+            for key, value in context.token_usage.items()
+            if type(value) is int and type(usage_before.get(key, 0)) is int
+        }
+        for key, value in (getattr(context, 'prompt_token_usage', {}) or {}).items():
+            if type(value) is int and type(prompt_usage_before.get(key, 0)) is int:
+                context.step_token_usage[key] = context.step_token_usage.get(key, 0) + value - prompt_usage_before.get(key, 0)
         duration_ms = int((time.monotonic() - started_monotonic) * 1000)
         completed_at = _now_iso()
 
@@ -840,16 +947,23 @@ def execute_plan(
             first_error = result.get('error') or result.get('summary')
 
         if status == STEP_STATUS_CANCELLED:
-            # An adapter reporting cancellation (rather than the probe firing between steps)
-            # still cancels the run.
             cancelled = True
 
         record = _step_record(context, step, index, status, result, started_at, completed_at, duration_ms)
+        record['effects_uncertain'] = (
+            step.get('capability_id') in ('agent_invoke', 'action_invoke') and status != STEP_STATUS_COMPLETED
+        )
+        record['token_usage'] = deepcopy(context.step_token_usage)
+        if checkpoints is not None and status == STEP_STATUS_COMPLETED:
+            checkpoints.commit(step, result, input_fingerprint)
+            record['checkpoint_available'] = True
         step_records.append(record)
-        _persist(persist, 'step', record)
+        persist_step(record)
         _emit(emit, {'type': 'step', 'phase': status, 'step_id': step_id,
                      'capability_id': step.get('capability_id'), 'step_index': index,
-                     'summary': record['summary'], 'completed': index + 1, 'total': total_units})
+                     'summary': record['summary'], 'failure': record['failure'],
+                     'checkpoint_available': record['checkpoint_available'],
+                     'completed': index + 1, 'total': total_units})
 
     # Resolve overall status. Cancellation wins; otherwise the run is complete when the
     # terminal step produced an answer, and failed when it did not.
@@ -858,12 +972,22 @@ def execute_plan(
     )
     if cancelled:
         run_status = PLAN_STATUS_CANCELLED
-    elif terminal_completed:
+    elif terminal_completed and not context.failures:
         run_status = PLAN_STATUS_COMPLETED
     else:
         run_status = PLAN_STATUS_FAILED
 
     message = _text((terminal_result or {}).get('message')) if terminal_result else ''
+    partial = bool(context.evidence or context.notes or any(
+        row['status'] == STEP_STATUS_COMPLETED and row['capability_id'] != CAPABILITY_RESPOND
+        for row in step_records
+    ))
+    outcome = 'cancelled' if cancelled else (
+        'completed' if run_status == PLAN_STATUS_COMPLETED else 'partial' if partial else 'failed'
+    )
+    if context.failures or not message:
+        explanation = failure_explanation(context.failures, partial=partial, cancelled=cancelled)
+        message = f'{message}\n\n{explanation}' if message else explanation
 
     capabilities_used = []
     for record in step_records:
@@ -878,6 +1002,9 @@ def execute_plan(
         'plan_id': getattr(context, 'plan_id', None) or (plan or {}).get('plan_id'),
         'conversation_id': getattr(context, 'conversation_id', None),
         'status': run_status,
+        'outcome': outcome,
+        'failure': context.failures[0] if context.failures else None,
+        'failures': list(context.failures),
         'message': message,
         'summary': _text((terminal_result or {}).get('summary')),
         'evidence': list(context.evidence or []),
@@ -897,6 +1024,9 @@ def execute_plan(
     _persist(persist, 'run', {
         'run_id': getattr(context, 'run_id', None),
         'status': run_status,
+        'outcome': outcome,
+        'failure': run_result['failure'],
+        'failures': run_result['failures'],
         'completed_at': run_result['completed_at'],
         'error': run_result['error'],
         'documents_touched': documents_touched,

--- a/application/single_app/functions_orchestration_plan_revisions.py
+++ b/application/single_app/functions_orchestration_plan_revisions.py
@@ -210,6 +210,7 @@ def _assert_editable(record):
     if (
         record.get('status') not in _EDITABLE_STATUSES or record.get('started_at')
         or 'superseded_by_run_id' in record
+        or record.get('retry_of_run_id') or record.get('checkpoints_deleted')
     ):
         raise _changed(record)
 
@@ -772,6 +773,10 @@ def claim_plan_run(
 ):
     """Atomically turn a current pre-execution plan into the one executable run."""
     record = read_revision_run(run_id, user_id, conversation_id)
+    if record.get('checkpoints_deleted') or record.get('latest_attempt_run_id'):
+        raise PlanRevisionError('This execution is no longer current.', code='already_run')
+    if record.get('retry_of_run_id') and edits:
+        raise PlanRevisionError('Retry uses the frozen effective plan.', code='plan_changed')
     if record.get('started_at') or record.get('status') in ('running', 'completed'):
         raise PlanRevisionError('This plan has already started.', code='already_run')
     if record.get('status') not in _RUNNABLE_STATUSES or 'superseded_by_run_id' in record:
@@ -796,6 +801,14 @@ def claim_plan_run(
         'status': 'running', 'started_at': now, 'edit_claim': None,
         'capabilities_used': list(summary['capabilities_used']),
     }
+    # Imported here to keep revision and execution state machines independent at
+    # module initialization; the lease is created in this same conditional claim.
+    from functions_orchestration_recovery import lease_fields
+
+    updates.update({
+        'execution_lease': lease_fields(), 'recovery_version': uuid.uuid4().hex,
+        'attempt_index': record.get('attempt_index') or 1,
+    })
     if conversation_context is not None:
         if not isinstance(conversation_context, dict):
             raise _invalid('Invalid conversation context.')

--- a/application/single_app/functions_orchestration_recovery.py
+++ b/application/single_app/functions_orchestration_recovery.py
@@ -1,0 +1,832 @@
+# functions_orchestration_recovery.py
+"""Execution leases and explicitly requested, checkpoint-only retry attempts.
+
+Version: 0.261.105
+Retry publication is one transactional parent CAS + child create. It never
+replans, invokes an adapter, or changes plan-revision lineage.
+"""
+
+import logging
+import threading
+import uuid
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+from azure.core import MatchConditions
+from azure.cosmos import exceptions
+
+import functions_orchestration_runs as run_store
+from functions_appinsights import log_event
+from functions_orchestration_checkpoints import (
+    CHECKPOINT_VERSION, CheckpointError, CheckpointStore, context_binding,
+    effective_plan, fingerprint, restore_context, step_input_fingerprint,
+)
+from functions_orchestration_plan_revisions import PlanRevisionError, read_revision_run
+from functions_orchestration_schema import build_failure, safe_failure, summarize_plan
+
+
+LEASE_SECONDS = 45
+HEARTBEAT_SECONDS = 10
+EFFECT_CAPABILITIES = {'agent_invoke', 'action_invoke'}
+_TERMINAL = {'completed', 'failed', 'cancelled'}
+_RETRY_FIELDS = {'conversation_id', 'submission_id', 'expected_version', 'confirm_external_effects'}
+
+
+class RecoveryError(RuntimeError):
+    def __init__(self, message=None, *, code='recovery_unavailable', status_code=409, recovery=None, current_run_id=None):
+        self.code = code
+        self.status_code = status_code
+        self.message = message or 'Saved progress is unavailable. Review the request and create a new plan.'
+        self.recovery = recovery
+        self.current_run_id = current_run_id
+        super().__init__(self.message)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _valid_id(value):
+    return isinstance(value, str) and 0 < len(value) <= 200 and value == value.strip() and not any(
+        ord(char) < 32 or 0xD800 <= ord(char) <= 0xDFFF or char in '/\\?#' for char in value
+    )
+
+
+def lease_fields():
+    return {
+        'token': uuid.uuid4().hex, 'expires_at': (_now() + timedelta(seconds=LEASE_SECONDS)).isoformat(),
+        'heartbeat_at': _now().isoformat(),
+    }
+
+
+def _live(record):
+    lease = record.get('execution_lease') or {}
+    if not lease.get('token'):
+        return False
+    try:
+        return datetime.fromisoformat(lease['expires_at']) > _now()
+    except (KeyError, ValueError, TypeError):
+        return True
+
+
+def _owned(run_id, user_id, conversation_id, authorize):
+    try:
+        if not callable(authorize) or authorize() is False:
+            raise RecoveryError(code='not_found', status_code=404)
+        record = read_revision_run(run_id, user_id, conversation_id)
+        if record.get('checkpoints_deleted'):
+            raise RecoveryError(code='not_found', status_code=404)
+        return record
+    except PlanRevisionError as exc:
+        raise RecoveryError('Run not found.', code='not_found', status_code=404) from exc
+
+
+def _replace(record, updates):
+    replacement = run_store._strip_cosmos_metadata(deepcopy(record))
+    replacement.update(deepcopy(updates))
+    replacement['updated_at'] = _now().isoformat()
+    return run_store.cosmos_orchestration_runs_container.replace_item(
+        item=record['id'], body=replacement, etag=record['_etag'],
+        match_condition=MatchConditions.IfNotModified,
+    )
+
+
+def checkpoint_store(record, authorize, *, token=None):
+    return CheckpointStore(
+        run_store.cosmos_orchestration_run_steps_container,
+        run_id=record['id'], user_id=record['user_id'], conversation_id=record['conversation_id'],
+        turn_id=record.get('turn_id') or record['plan'].get('turn_id'), authorize=authorize, token=token,
+    )
+
+
+def _publication_id(run_id):
+    return f'orchestration_guard_{fingerprint(run_id)[:40]}'
+
+
+def fence_publication(record, container):
+    if container is None:
+        return
+    item_id = _publication_id(record['id'])
+    for _ in range(8):
+        try:
+            existing = container.read_item(item=item_id, partition_key=record['conversation_id'])
+        except exceptions.CosmosResourceNotFoundError:
+            tombstone = {
+                'id': item_id, 'conversation_id': record['conversation_id'], 'user_id': record['user_id'],
+                'role': 'assistant_artifact', 'content': '', 'run_id': record['id'], 'token': None,
+                'metadata': {'is_generated_chat_artifact': True, 'orchestration_publication_guard': True},
+            }
+            try:
+                container.create_item(body=tombstone)
+                return
+            except exceptions.CosmosResourceExistsError:
+                continue
+        if existing.get('run_id') != record['id'] or existing.get('user_id') != record['user_id']:
+            raise CheckpointError('ownership_lost')
+        replacement = run_store._strip_cosmos_metadata(existing)
+        replacement['token'] = None
+        try:
+            container.replace_item(
+                item=item_id, body=replacement, etag=existing['_etag'],
+                match_condition=MatchConditions.IfNotModified,
+            )
+            return
+        except exceptions.CosmosAccessConditionFailedError:
+            continue
+    raise CheckpointError('ownership_lost')
+
+
+def _execution_steps(record):
+    """Inherited successes remain durable even before this attempt copies them."""
+    references = record.get('inherited_checkpoints') or {}
+    if not isinstance(references, dict):
+        raise CheckpointError('checkpoint_invalid')
+    expected = set(record.get('retry_reused_step_ids') or [])
+    if expected != set(references):
+        raise CheckpointError('checkpoint_invalid')
+    planned = {step['step_id']: step for step in record.get('plan', {}).get('steps') or []}
+    if set(references) - set(planned):
+        raise CheckpointError('checkpoint_invalid')
+    steps = {step['step_id']: deepcopy(step) for step in record.get('execution_steps') or []}
+    for step_id, reference in references.items():
+        if not isinstance(reference, dict) or not isinstance(reference.get('provenance'), dict):
+            raise CheckpointError('checkpoint_invalid')
+        if step_id in steps and steps[step_id].get('status') != 'completed':
+            raise CheckpointError('checkpoint_invalid')
+        steps.setdefault(step_id, {
+            'step_id': step_id, 'step_index': list(planned).index(step_id),
+            'capability_id': planned[step_id]['capability_id'], 'status': 'completed',
+            'checkpoint_available': True, 'effects_uncertain': False, 'reused': True,
+            'reused_from_run_id': reference['provenance'].get('run_id'),
+            'summary': 'Reused saved result',
+        })
+    return [steps[step_id] for step_id in planned if step_id in steps]
+
+
+def _validate_inherited_parent(record, parent):
+    if (
+        record.get('retry_of_run_id') != parent['id']
+        or parent.get('latest_attempt_run_id') != record['id']
+        or record.get('turn_id') != parent.get('turn_id')
+        or effective_plan(record['plan']) != effective_plan(parent['plan'])
+        or record.get('execution_binding') != parent.get('execution_binding')
+        or record.get('attempt_root_run_id') != (parent.get('attempt_root_run_id') or parent['id'])
+        or record.get('attempt_index') != (parent.get('attempt_index') or 1) + 1
+        or any(record.get(key) != parent.get(key) for key in (
+            'user_message_id', 'user_message', 'resolved_message', 'request_resolution',
+        ))
+    ):
+        raise CheckpointError('recovery_changed')
+
+
+def _completed_checkpoint(record, step_id, authorize, visited=None):
+    visited = set(visited or ())
+    if record['id'] in visited or len(visited) >= 128:
+        raise CheckpointError('checkpoint_invalid')
+    visited.add(record['id'])
+    steps = {step['step_id']: step for step in _execution_steps(record)}
+    if steps.get(step_id, {}).get('status') != 'completed':
+        raise CheckpointError('checkpoint_invalid')
+    reference = (record.get('inherited_checkpoints') or {}).get(step_id)
+    store = checkpoint_store(record, authorize)
+    if store.has_manifest(step_id):
+        payload = store.load(step_id)
+    elif reference:
+        if reference.get('source_run_id') != record.get('retry_of_run_id'):
+            raise CheckpointError('checkpoint_invalid')
+        try:
+            parent = _owned(reference['source_run_id'], record['user_id'], record['conversation_id'], authorize)
+        except RecoveryError as exc:
+            raise CheckpointError('context_unavailable') from exc
+        _validate_inherited_parent(record, parent)
+        payload = _completed_checkpoint(parent, step_id, authorize, visited)
+    else:
+        raise CheckpointError('checkpoint_unavailable')
+    if payload.get('binding') != record.get('execution_binding'):
+        raise CheckpointError('recovery_changed')
+    if not reference and payload.get('provenance') != {'run_id': record['id'], 'step_id': step_id}:
+        raise CheckpointError('checkpoint_invalid')
+    if reference and (
+        reference.get('payload_digest') != fingerprint(payload)
+        or reference.get('provenance') != payload.get('provenance')
+    ):
+        raise CheckpointError('checkpoint_invalid')
+    return payload
+
+
+def recovery_projection(record):
+    """Pure, read-only hints; POST revalidates every fact before publication."""
+    run_id = record.get('run_id') or record.get('id')
+    invalid = False
+    try:
+        steps = _execution_steps(record)
+    except CheckpointError:
+        steps = record.get('execution_steps') or []
+        invalid = True
+    reused = [
+        step['step_id'] for step in steps
+        if step.get('status') == 'completed' and step.get('capability_id') != 'respond'
+    ]
+    retry = [
+        step['step_id'] for step in record.get('plan', {}).get('steps') or []
+        if step.get('enabled', True) and (step['step_id'] not in reused or step.get('capability_id') == 'respond')
+    ]
+    uncertain = any(
+        step.get('capability_id') in EFFECT_CAPABILITIES and step.get('effects_uncertain')
+        for step in steps
+    )
+    reason, message = None, None
+    current = record.get('latest_attempt_run_id')
+    if current and current != run_id:
+        reason, message = 'recovery_changed', 'A newer execution attempt already exists.'
+    elif record.get('checkpoints_deleted'):
+        reason, message = 'context_unavailable', 'Executable recovery data was removed.'
+    elif record.get('checkpoint_version') != CHECKPOINT_VERSION or not record.get('execution_binding'):
+        reason, message = 'legacy_no_checkpoints', 'This run has no durable checkpoints and cannot resume. Create a new plan.'
+    elif _live(record):
+        reason, message = 'execution_live', 'This attempt is still running. Wait for it to finish or stop it.'
+    elif invalid:
+        reason, message = 'checkpoint_invalid', build_failure('checkpoint_invalid')['message']
+    elif record.get('status') == 'completed' and record.get('outcome', 'completed') == 'completed':
+        reason, message = 'already_completed', 'This request is already complete.'
+    elif not record.get('started_at'):
+        reason, message = 'not_started', 'This attempt has not started.'
+    elif record.get('recovery_blocked_code'):
+        reason = record['recovery_blocked_code']
+        message = build_failure(reason)['message']
+    elif (record.get('failure') or {}).get('code') == 'context_unavailable':
+        reason, message = 'context_unavailable', build_failure('context_unavailable')['message']
+    elif any(not step.get('checkpoint_available') for step in steps if step.get('step_id') in reused):
+        reason, message = 'checkpoint_unavailable', build_failure('checkpoint_unavailable')['message']
+    return {
+        'eligible': reason is None, 'reason_code': reason, 'message': message,
+        'expected_version': record.get('recovery_version'),
+        'source_run_id': run_id, 'retry_step_ids': retry, 'reused_step_ids': reused,
+        'requires_confirmation': uncertain,
+        **({'current_run_id': current} if current and current != run_id else {}),
+    }
+
+
+def reconcile_checkpoints(record, authorize):
+    """Read-only reconciliation of a crash after manifest commit but before progress.
+
+    A committed successful result is never replayed just because a later run-row
+    write was lost. Missing manifests on interrupted work remain uncertain.
+    """
+    updated = deepcopy(record)
+    current = record
+    visited = {record['id']}
+    while current.get('latest_attempt_run_id'):
+        target = current['latest_attempt_run_id']
+        if target in visited or len(visited) >= 128:
+            raise CheckpointError('checkpoint_invalid')
+        visited.add(target)
+        child = _owned(target, record['user_id'], record['conversation_id'], authorize)
+        if child.get('retry_of_run_id') != current['id'] or child.get('turn_id') != record.get('turn_id'):
+            raise CheckpointError('checkpoint_invalid')
+        updated['latest_attempt_run_id'] = target
+        current = child
+    if record.get('checkpoint_version') != CHECKPOINT_VERSION or record.get('checkpoints_deleted'):
+        return updated
+    updated['execution_steps'] = _execution_steps(record)
+    for step_id in record.get('inherited_checkpoints') or {}:
+        _completed_checkpoint(record, step_id, authorize)
+    store = checkpoint_store(record, authorize)
+    for step in updated.get('execution_steps') or []:
+        if step.get('status') not in ('running', 'failed') or step.get('capability_id') == 'respond':
+            continue
+        if store.has_manifest(step['step_id']):
+            payload = store.load(step['step_id'])
+            if payload.get('binding') != record.get('execution_binding'):
+                raise CheckpointError('checkpoint_invalid')
+            step.update({
+                'status': 'completed', 'checkpoint_available': True, 'effects_uncertain': False,
+                'failure': None, 'error': None, 'summary': payload['result'].get('summary') or 'Saved result',
+            })
+    return updated
+
+
+def public_execution_fields(record):
+    fields = {
+        'attempt_index': record.get('attempt_index') or 1,
+        'retry_of_run_id': record.get('retry_of_run_id'),
+        'failure': safe_failure(record['failure']) if record.get('failure') else None,
+        'failures': [safe_failure(value) for value in record.get('failures') or []],
+        'recovery': recovery_projection(record),
+    }
+    if record.get('outcome') in ('completed', 'partial', 'failed', 'cancelled'):
+        fields['outcome'] = record['outcome']
+    if record.get('latest_attempt_run_id'):
+        fields['latest_attempt_run_id'] = record['latest_attempt_run_id']
+    if record.get('finalization_status') in ('pending', 'saved', 'failed', 'interrupted'):
+        if _live(record):
+            fields['finalization_status'] = 'pending'
+        elif record.get('message_saved') is True and record.get('assistant_message_id'):
+            fields.update({'finalization_status': 'saved', 'message_saved': True})
+        elif record.get('message_saved') is False and record.get('finalization_status') == 'failed':
+            fields.update({'finalization_status': 'failed', 'message_saved': False})
+        else:
+            fields['finalization_status'] = 'interrupted'
+    if record.get('status') == 'running' and record.get('execution_lease') and not _live(record):
+        failure = build_failure('execution_expired')
+        fields.update({
+            'status': 'failed',
+            'outcome': 'partial' if fields['recovery']['reused_step_ids'] else 'failed',
+            'failure': fields['failure'] or failure, 'failures': fields['failures'] + [failure],
+        })
+    return fields
+
+
+class ExecutionLease:
+    """A worker-independent heartbeat, with fail-closed reads and conditional writes."""
+
+    def __init__(self, record, authorize, *, message_container=None):
+        self.run_id = record['id']
+        self.user_id = record['user_id']
+        self.conversation_id = record['conversation_id']
+        self.authorize = authorize
+        self.token = (record.get('execution_lease') or {}).get('token')
+        self.stopped = threading.Event()
+        self.failed = None
+        self.thread = None
+        self.lock = threading.RLock()
+        self.message_container = message_container
+
+    def publish_message(self, document):
+        """Fence and message are in the same container/partition: no stale publish."""
+        self.read()
+        if self.message_container is None:
+            raise CheckpointError('message_not_saved')
+        if (
+            document.get('id') != f'assistant_orchestration_{fingerprint(self.run_id)[:40]}'
+            or document.get('conversation_id') != self.conversation_id or document.get('role') != 'assistant'
+            or (document.get('metadata') or {}).get('orchestration', {}).get('run_id') != self.run_id
+        ):
+            raise CheckpointError('message_not_saved')
+        item_id = _publication_id(self.run_id)
+        guard = self.message_container.read_item(item=item_id, partition_key=self.conversation_id)
+        if not self._owns_publication_guard(guard):
+            raise CheckpointError('ownership_lost')
+        replacement = run_store._strip_cosmos_metadata(guard)
+        replacement['published_message_id'] = document['id']
+        replacement['document_digest'] = fingerprint(run_store._strip_cosmos_metadata(document))
+        try:
+            self.message_container.execute_item_batch(
+                batch_operations=[
+                    ('replace', (item_id, replacement), {'if_match_etag': guard['_etag']}),
+                    ('upsert', (document,)),
+                ], partition_key=self.conversation_id,
+            )
+        except Exception:
+            if not self._published_message_matches(document, replacement['document_digest']):
+                raise
+        self.read()
+
+    def _owns_publication_guard(self, guard):
+        return (
+            guard.get('id') == _publication_id(self.run_id)
+            and guard.get('conversation_id') == self.conversation_id
+            and guard.get('run_id') == self.run_id and guard.get('user_id') == self.user_id
+            and guard.get('token') == self.token and guard.get('role') == 'assistant_artifact'
+            and (guard.get('metadata') or {}).get('orchestration_publication_guard') is True
+        )
+
+    def _published_message_matches(self, document, digest):
+        """A lost batch acknowledgement is success only for this exact publication."""
+        self.read()
+        try:
+            guard = self.message_container.read_item(
+                item=_publication_id(self.run_id), partition_key=self.conversation_id,
+            )
+            saved = self.message_container.read_item(item=document['id'], partition_key=self.conversation_id)
+        except exceptions.CosmosResourceNotFoundError:
+            return False
+        matches = (
+            self._owns_publication_guard(guard)
+            and guard.get('published_message_id') == document['id']
+            and guard.get('document_digest') == digest
+            and fingerprint(run_store._strip_cosmos_metadata(saved)) == digest
+        )
+        self.read()
+        return matches
+
+    def read(self):
+        if self.failed:
+            raise self.failed
+        record = _owned(self.run_id, self.user_id, self.conversation_id, self.authorize)
+        if (
+            not self.token or (record.get('execution_lease') or {}).get('token') != self.token
+            or not _live(record) or record.get('latest_attempt_run_id') not in (None, self.run_id)
+        ):
+            raise CheckpointError('ownership_lost')
+        return record
+
+    def update(self, updates):
+        with self.lock:
+            for _ in range(8):
+                record = self.read()
+                try:
+                    return _replace(record, updates)
+                except exceptions.CosmosAccessConditionFailedError:
+                    continue
+                except Exception:
+                    saved = _owned(self.run_id, self.user_id, self.conversation_id, self.authorize)
+                    released = 'execution_lease' in updates and updates['execution_lease'] is None
+                    owned = (
+                        saved.get('latest_attempt_run_id') in (None, self.run_id)
+                        and (
+                            ((saved.get('execution_lease') or {}).get('token') == self.token and _live(saved))
+                            or (released and saved.get('execution_lease') is None)
+                        )
+                    )
+                    if owned and all(saved.get(key) == value for key, value in updates.items()):
+                        return saved
+                    raise
+            raise CheckpointError('ownership_lost')
+
+    def renew(self):
+        self.update({'execution_lease': {
+            'token': self.token, 'heartbeat_at': _now().isoformat(),
+            'expires_at': (_now() + timedelta(seconds=LEASE_SECONDS)).isoformat(),
+        }})
+
+    def cancel_requested(self):
+        return bool(self.read().get('cancellation_requested_at'))
+
+    def start(self):
+        self.update({'finalization_status': 'pending'})
+        if self.message_container is not None:
+            guard = {
+                'id': _publication_id(self.run_id), 'conversation_id': self.conversation_id,
+                'user_id': self.user_id, 'run_id': self.run_id, 'token': self.token,
+                'role': 'assistant_artifact', 'content': '',
+                'metadata': {'is_generated_chat_artifact': True, 'orchestration_publication_guard': True},
+            }
+            self.message_container.create_item(body=guard)
+
+        def heartbeat():
+            while not self.stopped.wait(HEARTBEAT_SECONDS):
+                try:
+                    self.renew()
+                except Exception as exc:
+                    self.failed = CheckpointError('ownership_lost')
+                    log_event(
+                        '[ORCHESTRATION_RUNS] Execution heartbeat failed closed.',
+                        extra={'run_id': self.run_id, 'error_type': type(exc).__name__}, level=logging.ERROR,
+                    )
+                    return
+
+        self.thread = threading.Thread(target=heartbeat, name=f'orchestration-lease-{self.run_id}', daemon=True)
+        self.thread.start()
+        return self
+
+    def close(self, *, release=False):
+        self.stopped.set()
+        if self.thread and self.thread is not threading.current_thread():
+            self.thread.join(timeout=HEARTBEAT_SECONDS + 1)
+        if release:
+            return self.update({'execution_lease': None})
+
+
+def request_cancellation(run_id, user_id, conversation_id, authorize):
+    for _ in range(8):
+        record = _owned(run_id, user_id, conversation_id, authorize)
+        if record.get('status') in _TERMINAL and not _live(record):
+            return record
+        try:
+            return _replace(record, {
+                'cancellation_requested_at': record.get('cancellation_requested_at') or _now().isoformat(),
+                'cancellation_requested_by': user_id,
+            })
+        except exceptions.CosmosAccessConditionFailedError:
+            continue
+    raise RecoveryError('The cancellation could not be saved. Please retry.', status_code=503)
+
+
+def _validate_payload_sources(payload, context, settings, user_id):
+    # Lazy import avoids initializing adapter services in storage-only callers.
+    from functions_orchestration_adapters import resolve_context_source_manifest
+
+    state = payload.get('state') or {}
+    saved = state.get('execution_manifest') or []
+    document_ids = set(state.get('documents_touched') or [])
+    document_ids.update(
+        citation['document_id'] for citation in state.get('citations') or []
+        if isinstance(citation, dict) and citation.get('document_id')
+    )
+    if document_ids:
+        fresh = resolve_context_source_manifest(context, sorted(document_ids), settings=settings, user_id=user_id)
+        by_id = {item.get('document_id'): item for item in fresh}
+        original = {item.get('document_id'): item for item in saved}
+        for document_id in document_ids:
+            current = by_id.get(document_id) or {}
+            prior = original.get(document_id) or {}
+            if (
+                current.get('authorization_status') != 'authorized'
+                or not prior or prior.get('source_version') != current.get('source_version')
+                or prior.get('source_revision') != current.get('source_revision')
+                or (prior.get('source_version') is None and not prior.get('source_revision'))
+                or prior.get('scope') != current.get('scope')
+                or prior.get('scope_id') != current.get('scope_id')
+            ):
+                raise CheckpointError('context_unavailable')
+    artifacts = state.get('artifacts') or []
+    if artifacts:
+        validate_artifacts = getattr(context, 'validate_checkpoint_artifacts', None)
+        if not callable(validate_artifacts) or validate_artifacts(artifacts) is not True:
+            raise CheckpointError('context_unavailable')
+        versions = getattr(context, 'checkpoint_artifact_versions', None)
+        if not callable(versions) or versions(artifacts) != payload.get('artifact_versions'):
+            raise CheckpointError('context_unavailable')
+
+
+def validate_resume(record, context, settings, authorize, *, source_run_id=None):
+    """Reconstruct from persisted data without invoking any capability."""
+    source_id = source_run_id or record.get('retry_of_run_id') or record['id']
+    source = _owned(source_id, record['user_id'], record['conversation_id'], authorize)
+    if (
+        (source.get('turn_id') or source['plan'].get('turn_id')) != (record.get('turn_id') or record['plan'].get('turn_id'))
+        or effective_plan(source['plan']) != effective_plan(record['plan'])
+        or (source_id != record['id'] and source.get('latest_attempt_run_id') != record['id'])
+    ):
+        raise CheckpointError('recovery_changed')
+    source = reconcile_checkpoints(source, authorize)
+    binding = context_binding(context, record['plan'], settings)
+    if source.get('execution_binding') != binding:
+        raise CheckpointError('recovery_changed')
+    source_steps = {step['step_id']: step for step in _execution_steps(source)}
+    payloads = {}
+    initial_state = {key: deepcopy(getattr(context, key, None)) for key in (
+        'evidence', 'citations', 'artifacts', 'notes', 'documents_touched', 'step_documents',
+        'execution_manifest', 'source_manifest',
+    )}
+    try:
+        context.execution_manifest = deepcopy(source.get('execution_initial_manifest') or [])
+        interrupted = False
+        for step in record['plan'].get('steps') or []:
+            if not step.get('enabled', True) or step.get('capability_id') == 'respond':
+                continue
+            saved = source_steps.get(step['step_id']) or {}
+            if saved.get('status') != 'completed':
+                interrupted = True
+                continue
+            # A later success consumed the old earlier_findings. Never repair that
+            # invalid input by silently repeating a successful external operation.
+            if interrupted:
+                raise CheckpointError('recovery_changed')
+            payload = _completed_checkpoint(source, step['step_id'], authorize)
+            if (
+                payload.get('binding') != binding
+                or payload.get('input_fingerprint') != step_input_fingerprint(step, context, binding)
+            ):
+                raise CheckpointError('recovery_changed')
+            _validate_payload_sources(payload, context, settings, record['user_id'])
+            restore_context(context, payload)
+            payloads[step['step_id']] = payload
+    finally:
+        for key, value in initial_state.items():
+            setattr(context, key, value)
+    return payloads
+
+
+def prepare_retry(run_id, user_id, data, *, authorize, validate, message_container=None):
+    if (
+        not isinstance(data, dict) or set(data) - _RETRY_FIELDS
+        or not all(_valid_id(data.get(key)) for key in ('conversation_id', 'submission_id', 'expected_version'))
+        or type(data.get('confirm_external_effects', False)) is not bool
+    ):
+        raise RecoveryError('Invalid retry request.', code='invalid_request', status_code=400)
+    conversation_id = data['conversation_id']
+    record = _owned(run_id, user_id, conversation_id, authorize)
+    request_digest = fingerprint(data)
+    submission = record.get('retry_submission') or {}
+    if submission.get('submission_id') == data['submission_id']:
+        if submission.get('fingerprint') != request_digest:
+            raise RecoveryError('This retry submission changed.', code='recovery_changed')
+        return _owned(submission['run_id'], user_id, conversation_id, authorize)
+    record = reconcile_checkpoints(record, authorize)
+    recovery = recovery_projection(record)
+    if record.get('recovery_version') != data['expected_version'] or recovery.get('current_run_id'):
+        raise RecoveryError(
+            'The recovery state changed. Reload this run.', code='recovery_changed',
+            recovery=recovery, current_run_id=recovery.get('current_run_id'),
+        )
+    if not recovery['eligible']:
+        raise RecoveryError(recovery['message'], recovery=recovery)
+    if recovery['requires_confirmation'] and not data.get('confirm_external_effects'):
+        raise RecoveryError(
+            'This step may already have performed external actions. Confirm before retrying.',
+            code='confirmation_required', recovery=recovery,
+        )
+    if not callable(validate):
+        raise RecoveryError()
+    try:
+        payloads = validate(record)
+        if not isinstance(payloads, dict) or set(payloads) != set(recovery['reused_step_ids']):
+            raise CheckpointError('checkpoint_invalid')
+    except CheckpointError as exc:
+        blocked = {**recovery, 'eligible': False, 'reason_code': exc.code, 'message': exc.failure['message']}
+        raise RecoveryError(exc.failure['message'], recovery=blocked) from exc
+    except (ValueError, PermissionError) as exc:
+        raise RecoveryError(build_failure('context_unavailable')['message']) from exc
+
+    # Fence the steps partition first. If the later parent CAS loses, the old
+    # attempt remains safely fenced and the winning successor is authoritative.
+    checkpoint_store(record, authorize).fence(allow_missing=bool(record.get('inherited_checkpoints')))
+    fence_publication(record, message_container)
+    current = _owned(run_id, user_id, conversation_id, authorize)
+    if current.get('_etag') != record.get('_etag'):
+        raise RecoveryError('The recovery state changed. Reload this run.', code='recovery_changed')
+    child_id = f'run_{uuid.uuid4().hex}'
+    child = run_store._strip_cosmos_metadata(deepcopy(record))
+    for key in (
+        'execution_steps', 'execution_lease', 'failure', 'failures', 'outcome',
+        'assistant_message_id', 'cancellation_requested_at', 'cancellation_requested_by',
+        'retry_submission', 'latest_attempt_run_id', 'recovery_blocked_code', 'message_saved',
+        'edit_claim', 'edit_pending', 'edit_narrowing', 'terminal_publication', 'finalization_status',
+        'inherited_checkpoints',
+    ):
+        child.pop(key, None)
+    child.update({
+        'id': child_id, 'run_id': child_id, 'status': 'awaiting_approval',
+        'created_at': _now().isoformat(), 'started_at': None, 'completed_at': None,
+        'error': None, 'token_usage': {}, 'planning_token_usage': {},
+        'artifacts': [], 'documents_touched': [], 'execution_steps': [],
+        'retry_of_run_id': run_id, 'attempt_index': (record.get('attempt_index') or 1) + 1,
+        'attempt_root_run_id': record.get('attempt_root_run_id') or run_id,
+        'recovery_version': uuid.uuid4().hex, 'edit_version': uuid.uuid4().hex,
+        'retry_reused_step_ids': recovery['reused_step_ids'],
+        'retry_confirmed_external_effects': bool(data.get('confirm_external_effects')),
+        'inherited_checkpoints': {
+            step_id: {
+                'source_run_id': run_id, 'payload_digest': fingerprint(payload),
+                'provenance': deepcopy(payload['provenance']),
+            } for step_id, payload in payloads.items()
+        },
+    })
+    child['plan'] = deepcopy(record['plan'])
+    child['plan'].update({'run_id': child_id, 'status': 'awaiting_approval', 'edit_version': child['edit_version']})
+    for step in child['plan'].get('steps') or []:
+        step['status'] = 'pending'
+    child['approval'] = {
+        **(child['plan'].get('approval') or {}), 'mode': 'manual', 'state': 'pending',
+        'approved_at': None, 'approved_by': None,
+    }
+    child['plan']['approval'] = deepcopy(child['approval'])
+    child['plan_summary'] = summarize_plan(child['plan'])
+    child['execution_steps'] = _execution_steps(child)
+    parent = run_store._strip_cosmos_metadata(deepcopy(record))
+    parent.update({
+        'latest_attempt_run_id': child_id, 'execution_lease': None,
+        'retry_submission': {'submission_id': data['submission_id'], 'fingerprint': request_digest, 'run_id': child_id},
+    })
+    if parent.get('status') not in _TERMINAL:
+        failure = build_failure('execution_expired')
+        parent.update({
+            'status': 'failed', 'outcome': 'failed', 'failure': failure,
+            'failures': [failure], 'error': failure['message'], 'completed_at': _now().isoformat(),
+        })
+    try:
+        run_store.cosmos_orchestration_runs_container.execute_item_batch(
+            batch_operations=[
+                ('replace', (run_id, parent), {'if_match_etag': record['_etag']}),
+                ('create', (child,)),
+            ], partition_key=conversation_id,
+        )
+    except Exception as exc:
+        # An ambiguous response can be a committed batch. A repeated stable request
+        # returns that same child, including after a process restart.
+        latest = _owned(run_id, user_id, conversation_id, authorize)
+        saved = latest.get('retry_submission') or {}
+        if saved.get('submission_id') == data['submission_id'] and saved.get('fingerprint') == request_digest:
+            return _owned(saved['run_id'], user_id, conversation_id, authorize)
+        if latest.get('latest_attempt_run_id'):
+            raise RecoveryError(
+                'A newer attempt already exists.', code='recovery_changed',
+                current_run_id=latest['latest_attempt_run_id'],
+            ) from exc
+        raise RecoveryError('Retry preparation could not be saved. Retry the same request.', status_code=503) from exc
+    return _owned(child_id, user_id, conversation_id, authorize)
+
+
+class ExecutionCheckpoints:
+    def __init__(self, record, context, settings, lease):
+        self.record = record
+        self.context = context
+        self.settings = settings
+        self.lease = lease
+        self.binding = context_binding(context, record['plan'], settings)
+        self.store = checkpoint_store(record, lease.read, token=lease.token)
+        self.reused = validate_resume(record, context, settings, lease.authorize) if record.get('retry_of_run_id') else {}
+        self.records = _execution_steps(record)
+
+    def initialize(self):
+        self.lease.update({
+            'checkpoint_version': CHECKPOINT_VERSION, 'execution_binding': self.binding,
+            'execution_steps': deepcopy(self.records), 'attempt_index': self.record.get('attempt_index') or 1,
+            'execution_initial_manifest': deepcopy(self.context.execution_manifest),
+        })
+        self.store.initialize()
+
+    def before_step(self, step):
+        self.lease.read()
+        revalidate = getattr(self.context, 'revalidate_conversation_context', None)
+        if callable(revalidate):
+            revalidate()
+        value = self.reused.get(step['step_id'])
+        if value:
+            if value['input_fingerprint'] != step_input_fingerprint(step, self.context, self.binding):
+                raise CheckpointError('recovery_changed')
+            _validate_payload_sources(value, self.context, self.settings, self.record['user_id'])
+        return value
+
+    def save_step(self, record):
+        self.store.save_step(record)
+        self.records = [row for row in self.records if row['step_id'] != record['step_id']] + [deepcopy(record)]
+        self.lease.update({'execution_steps': self.records})
+
+    def commit(self, step, result, input_fingerprint, *, reused=None):
+        self.lease.read()
+        if not reused and self.context.documents_touched:
+            # Capture versions for search-discovered sources as well as named ones.
+            from functions_orchestration_adapters import resolve_context_source_manifest
+
+            manifest = resolve_context_source_manifest(
+                self.context, self.context.documents_touched, settings=self.settings, user_id=self.record['user_id'],
+            )
+            if any(
+                not any(item.get('document_id') == document_id and item.get('authorization_status') == 'authorized' for item in manifest)
+                for document_id in self.context.documents_touched
+            ):
+                raise CheckpointError('context_unavailable')
+            self.context.execution_manifest = manifest
+        versions = (reused or {}).get('artifact_versions') or {}
+        if not reused and self.context.artifacts:
+            resolve_versions = getattr(self.context, 'checkpoint_artifact_versions', None)
+            if not callable(resolve_versions):
+                raise CheckpointError('context_unavailable')
+            versions = resolve_versions(self.context.artifacts)
+        self.store.commit(
+            step, result, self.context, input_fingerprint=input_fingerprint, binding=self.binding,
+            provenance=(reused or {}).get('provenance'),
+            artifact_versions=versions,
+        )
+
+
+def cleanup_conversation_checkpoints(conversation_id, user_id, authorize, *, message_container=None, conversation_container=None):
+    """Explicit retention cleanup; no TTL or optional blob container is assumed."""
+    if not callable(authorize) or authorize() is False:
+        raise RecoveryError(code='not_found', status_code=404)
+    if conversation_container is not None:
+        for _ in range(8):
+            conversation = conversation_container.read_item(item=conversation_id, partition_key=conversation_id)
+            if conversation.get('user_id') != user_id:
+                raise RecoveryError(code='not_found', status_code=404)
+            replacement = run_store._strip_cosmos_metadata(conversation)
+            replacement['orchestration_deleted'] = True
+            try:
+                conversation_container.replace_item(
+                    item=conversation_id, body=replacement, etag=conversation['_etag'],
+                    match_condition=MatchConditions.IfNotModified,
+                )
+                break
+            except exceptions.CosmosAccessConditionFailedError:
+                continue
+        else:
+            raise CheckpointError()
+    rows = list(run_store.cosmos_orchestration_runs_container.query_items(
+        query='SELECT * FROM c WHERE c.conversation_id = @conversation_id AND c.user_id = @user_id',
+        parameters=[{'name': '@conversation_id', 'value': conversation_id}, {'name': '@user_id', 'value': user_id}],
+        partition_key=conversation_id,
+    ))
+    visited = set()
+    for row in rows:
+        if row['id'] in visited:
+            continue
+        visited.add(row['id'])
+        if not run_store._is_run_record(row) or row.get('user_id') != user_id:
+            continue
+        for _ in range(8):
+            current = read_revision_run(row['id'], user_id, conversation_id)
+            try:
+                _replace(current, {'checkpoints_deleted': True, 'execution_lease': None, 'recovery_blocked_code': 'context_unavailable'})
+                break
+            except exceptions.CosmosAccessConditionFailedError:
+                continue
+        else:
+            raise CheckpointError()
+        if current.get('latest_attempt_run_id') and current['latest_attempt_run_id'] not in visited:
+            rows.append(read_revision_run(current['latest_attempt_run_id'], user_id, conversation_id))
+        fence_publication(row, message_container)
+        if current.get('checkpoint_version') == CHECKPOINT_VERSION:
+            store = checkpoint_store(row, authorize)
+            # initialize may have failed before creating the guard. A tombstone
+            # still has to exist to prevent a delayed initializer from succeeding.
+            try:
+                store.container.create_item(body={
+                    **store.identity, 'id': 'checkpoint:lifecycle',
+                    'record_type': 'checkpoint_lifecycle', 'token': None, 'deleted': True,
+                })
+            except exceptions.CosmosResourceExistsError:
+                pass
+            store.delete_payloads()

--- a/application/single_app/functions_orchestration_runs.py
+++ b/application/single_app/functions_orchestration_runs.py
@@ -45,6 +45,7 @@ from functions_orchestration_schema import (
     new_run_id,
     new_step_id,
     summarize_plan,
+    safe_failure,
 )
 
 _LOG_PREFIX = '[ORCHESTRATION_RUNS]'
@@ -432,7 +433,7 @@ def _publish_replanned_run(record, expected_previous_run, *, idempotent=False):
     return record
 
 
-def get_orchestration_run(run_id, user_id, conversation_id=None):
+def get_orchestration_run(run_id, user_id, conversation_id=None, *, strict=False):
     """Fetch one run, returning ``None`` unless it exists and belongs to ``user_id``.
 
     A ``conversation_id`` turns this into a point read; without one it is a cross-partition
@@ -465,6 +466,8 @@ def get_orchestration_run(run_id, user_id, conversation_id=None):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
+        if strict:
+            raise
         return None
 
     if not _is_run_record(item):
@@ -516,41 +519,37 @@ def update_orchestration_run(run_id, user_id, updates, conversation_id=None):
     changing ``conversation_id`` or ``user_id`` on an existing item would move it or reassign
     it rather than update it.
     """
-    existing = get_orchestration_run(run_id, user_id, conversation_id=conversation_id)
-    if not existing:
-        return None
-
-    updates = updates if isinstance(updates, dict) else {}
+    if not conversation_id:
+        found = get_orchestration_run(run_id, user_id)
+        if not found:
+            return None
+        conversation_id = found['conversation_id']
     protected = {'id', 'record_type', 'run_id', 'conversation_id', 'user_id', 'created_at'}
-    for key, value in updates.items():
-        if key in protected:
+    for _ in range(8):
+        try:
+            current = cosmos_orchestration_runs_container.read_item(item=run_id, partition_key=conversation_id)
+        except exceptions.CosmosResourceNotFoundError:
+            return None
+        if not _is_run_record(current) or current.get('user_id') != user_id or current.get('checkpoints_deleted'):
+            return None
+        existing = _strip_cosmos_metadata(deepcopy(current))
+        existing.update({key: value for key, value in (updates or {}).items() if key not in protected})
+        if isinstance((updates or {}).get('plan'), dict):
+            summary = summarize_plan(updates['plan'])
+            existing.update({'plan_summary': summary, 'capabilities_used': list(summary.get('capabilities_used') or [])})
+        existing['updated_at'] = _utc_now_iso()
+        try:
+            result = cosmos_orchestration_runs_container.replace_item(
+                item=run_id, body=existing, etag=current['_etag'],
+                match_condition=MatchConditions.IfNotModified,
+            )
+            return _strip_cosmos_metadata(result)
+        except exceptions.CosmosAccessConditionFailedError:
             continue
-        existing[key] = value
-
-    # If the plan document itself was replaced (a re-plan), keep the denormalised summary and
-    # capability list in step with it rather than letting the ledger read a stale summary.
-    if isinstance(updates.get('plan'), dict):
-        summary = summarize_plan(updates['plan'])
-        existing['plan_summary'] = summary
-        existing['capabilities_used'] = list((summary or {}).get('capabilities_used') or [])
-
-    existing['updated_at'] = _utc_now_iso()
-
-    try:
-        result = cosmos_orchestration_runs_container.upsert_item(body=existing)
-    except Exception as exc:
-        log_event(
-            f'{_LOG_PREFIX} Failed to update run {run_id}: {exc}',
-            extra={'user_id': user_id, 'run_id': run_id},
-            level=logging.ERROR,
-            exceptionTraceback=True,
-        )
-        raise
-
-    return _strip_cosmos_metadata(result)
+    raise exceptions.CosmosAccessConditionFailedError(status_code=412, message='Run changed.')
 
 
-def list_conversation_runs(conversation_id, user_id, limit=10):
+def list_conversation_runs(conversation_id, user_id, limit=10, *, strict=False):
     """A conversation's runs for this user, oldest first.
 
     Ordered so the ledger builder can read it as "newest last": the query pulls the most
@@ -582,6 +581,8 @@ def list_conversation_runs(conversation_id, user_id, limit=10):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
+        if strict:
+            raise
         return []
 
     trimmed = [
@@ -941,7 +942,7 @@ def save_orchestration_step(run_id, step_record):
     return _strip_cosmos_metadata(result)
 
 
-def list_run_steps(run_id, user_id=None, conversation_id=None):
+def list_run_steps(run_id, user_id=None, conversation_id=None, *, strict=False):
     """Steps of a run in execution order.
 
     Steps carry only ``run_id``, so ownership can only be proven through the parent run. When
@@ -952,7 +953,7 @@ def list_run_steps(run_id, user_id=None, conversation_id=None):
         return []
 
     if user_id is not None and not get_orchestration_run(
-        run_id, user_id, conversation_id=conversation_id
+        run_id, user_id, conversation_id=conversation_id, strict=strict,
     ):
         return []
 
@@ -971,6 +972,25 @@ def list_run_steps(run_id, user_id=None, conversation_id=None):
             level=logging.ERROR,
             exceptionTraceback=True,
         )
+        if strict:
+            raise
         return []
 
-    return [_strip_cosmos_metadata(item) for item in items]
+    return [public_step_record(item) for item in items if item.get('record_type') in (None, 'step')]
+
+
+def public_step_record(item):
+    """Checkpoint chunks/manifests and future private fields never cross this boundary."""
+    fields = (
+        'run_id', 'step_id', 'step_index', 'capability_id', 'title', 'status',
+        'started_at', 'completed_at', 'duration_ms', 'reused', 'reused_from_run_id',
+        'checkpoint_available',
+    )
+    row = {key: deepcopy(item[key]) for key in fields if key in item}
+    row['failure'] = safe_failure(item['failure']) if item.get('failure') else None
+    failed = item.get('status') in ('failed', 'cancelled')
+    row['summary'] = (
+        (row['failure'] or {}).get('message') or 'This step did not complete.'
+    ) if failed else item.get('summary') or ''
+    row['error'] = row['failure']['message'] if row['failure'] else None
+    return row

--- a/application/single_app/functions_orchestration_schema.py
+++ b/application/single_app/functions_orchestration_schema.py
@@ -40,6 +40,10 @@ import logging
 import math
 import uuid
 
+from azure.core.exceptions import ServiceRequestError
+from openai import APIConnectionError, APITimeoutError
+
+from agent_execution_context import AgentDelegationTimeout
 from functions_appinsights import log_event
 from functions_orchestration_registry import (
     CAPABILITY_ACTION_INVOKE,
@@ -1058,6 +1062,83 @@ def summarize_plan(plan):
 # Step results
 # --------------------------------------------------------------------------------------
 
+FAILURE_CONTRACT_VERSION = 1
+FAILURE_MESSAGES = {
+    'user_cancelled': 'You stopped this run. Already submitted external actions may still finish.',
+    'step_timeout': 'This step did not finish before its time limit.',
+    'run_timeout': 'The run reached its total time limit before all work could finish.',
+    'step_budget': 'The run reached its step limit before all work could finish.',
+    'delegation_timeout': 'The delegated agent did not finish before its time limit.',
+    'provider_timeout': 'The service used by this step timed out.',
+    'provider_http_error': 'The service used by this step returned an unsuccessful HTTP response.',
+    'connection_failed': 'This step could not connect to the service it uses.',
+    'execution_interrupted': 'This step stopped unexpectedly. The underlying cause was not recorded.',
+    'execution_expired': 'The execution lease expired before the worker recorded a final outcome.',
+    'ownership_lost': 'This execution no longer owns the attempt and cannot publish further results.',
+    'context_unavailable': 'The original context or access changed. Review the request and create a new plan.',
+    'checkpoint_unavailable': 'Progress could not be saved or verified. This attempt cannot safely resume.',
+    'checkpoint_invalid': 'Saved progress could not be verified. Review the request and create a new plan.',
+    'recovery_changed': 'Saved step inputs changed. Previously completed work will not be repeated.',
+    'model_failed': 'The answering model could not complete the reply.',
+    'step_failed': 'This operation could not complete.',
+    'message_not_saved': 'The explanation could not be saved. Reload this run to check its durable status.',
+}
+
+
+def build_failure(code='step_failed', *, step_id=None, capability_id=None, provider_status=None):
+    """Only application-owned text may cross a failure boundary."""
+    code = code if code in FAILURE_MESSAGES else 'step_failed'
+    result = {'code': code, 'message': FAILURE_MESSAGES[code]}
+    if step_id:
+        result['step_id'] = _text(step_id, 200)
+    if capability_id:
+        result['capability_id'] = _text(capability_id, 100)
+    if isinstance(provider_status, int) and not isinstance(provider_status, bool) and 400 <= provider_status <= 599:
+        result['provider_status'] = provider_status
+        if code == 'provider_http_error':
+            result['message'] = f'The service used by this step returned HTTP {provider_status}.'
+    return result
+
+
+def safe_failure(value, *, step_id=None, capability_id=None):
+    value = value if isinstance(value, dict) else {}
+    return build_failure(
+        value.get('code'), step_id=step_id or value.get('step_id'),
+        capability_id=capability_id or value.get('capability_id'),
+        provider_status=value.get('provider_status'),
+    )
+
+
+def failure_from_exception(exc, *, answering=False, _depth=0):
+    """Use types and structured status, never diagnostic prose or model content."""
+    status = getattr(exc, 'status_code', None)
+    if not isinstance(status, int):
+        status = getattr(getattr(exc, 'response', None), 'status_code', None)
+    if isinstance(status, int) and 400 <= status <= 599:
+        return build_failure('provider_http_error', provider_status=status)
+    if isinstance(exc, AgentDelegationTimeout):
+        return build_failure('delegation_timeout')
+    if isinstance(exc, (TimeoutError, APITimeoutError)):
+        return build_failure('provider_timeout')
+    if isinstance(exc, (ConnectionError, APIConnectionError, ServiceRequestError)):
+        return build_failure('connection_failed')
+    cause = getattr(exc, '__cause__', None)
+    if cause is not None and cause is not exc and _depth < 3:
+        return failure_from_exception(cause, answering=answering, _depth=_depth + 1)
+    return build_failure('model_failed' if answering else 'step_failed')
+
+
+def failure_explanation(failures, *, partial=False, cancelled=False):
+    facts = [safe_failure(value)['message'] for value in failures or []]
+    facts = list(dict.fromkeys(facts))
+    heading = 'The run was stopped.' if cancelled else (
+        'The request was only partially completed.' if partial else 'The request could not be completed.'
+    )
+    return heading + ('\n\n' + '\n'.join(facts) if facts else '') + (
+        '\n\nCheck the run details for saved progress and retry availability.'
+    )
+
+
 def build_step_result(
     status=STEP_STATUS_COMPLETED,
     summary='',
@@ -1068,6 +1149,7 @@ def build_step_result(
     error=None,
     replan_hint=None,
     message=None,
+    failure=None,
 ):
     """The single shape every capability adapter returns.
 
@@ -1095,6 +1177,7 @@ def build_step_result(
         'error': _text(error) or None,
         'replan_hint': _text(replan_hint) or None,
         'message': message,
+        'failure': safe_failure(failure) if failure else None,
     }
 
 

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -66,6 +66,7 @@ from functions_simplechat_operations import (
 from swagger_wrapper import swagger_route, get_auth_security
 from functions_activity_logging import log_conversation_creation, log_conversation_deletion, log_conversation_archival
 from functions_thoughts import archive_thoughts_for_conversation, delete_thoughts_for_conversation
+from functions_orchestration_recovery import cleanup_conversation_checkpoints
 from utils_cache import invalidate_personal_search_cache
 
 def normalize_chat_type(conversation_item):
@@ -1457,6 +1458,20 @@ def register_route_backend_conversations(bp):
                 "error": str(e)
             }), 500
 
+        try:
+            cleanup_conversation_checkpoints(
+                conversation_id, user_id,
+                lambda: _authorize_personal_conversation_read(user_id, conversation_id),
+                message_container=cosmos_messages_container,
+                conversation_container=cosmos_conversations_container,
+            )
+        except Exception as exc:
+            log_event(
+                '[ORCHESTRATION_RUNS] Conversation recovery cleanup failed.',
+                extra={'conversation_id': conversation_id, 'error_type': type(exc).__name__}, level=logging.ERROR,
+            )
+            return jsonify({'error': 'Execution data could not be removed. Please retry deletion.'}), 503
+
         if archiving_enabled:
             archived_item = dict(conversation_item)
             archived_item["archived_at"] = datetime.utcnow().isoformat()
@@ -1581,6 +1596,13 @@ def register_route_backend_conversations(bp):
                 except (LookupError, PermissionError):
                     failed_ids.append(conversation_id)
                     continue
+
+                cleanup_conversation_checkpoints(
+                    conversation_id, user_id,
+                    lambda: _authorize_personal_conversation_read(user_id, conversation_id),
+                    message_container=cosmos_messages_container,
+                    conversation_container=cosmos_conversations_container,
+                )
                 
                 # Archive if enabled
                 if archiving_enabled:

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -32,6 +32,7 @@ from datetime import datetime, timezone
 
 from azure.cosmos import exceptions
 from azure.core.exceptions import AzureError
+from azure.core import MatchConditions
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
 from flask import Response, jsonify, request, session, stream_with_context
 from openai import OpenAIError
@@ -91,6 +92,13 @@ from functions_orchestration_events import (
     serialize_sse,
 )
 from functions_orchestration_executor import RunContext, execute_plan
+from functions_orchestration_adapters import resolve_context_source_manifest
+from functions_orchestration_checkpoints import CheckpointError, fingerprint
+from functions_orchestration_recovery import (
+    ExecutionCheckpoints, ExecutionLease, RecoveryError, prepare_retry,
+    public_execution_fields, recovery_projection, request_cancellation, validate_resume,
+    reconcile_checkpoints,
+)
 from functions_orchestration_memory import (
     OrchestrationMemoryError,
     load_orchestration_memory,
@@ -146,6 +154,7 @@ from functions_orchestration_runs import (
     prepare_elicitation_outcome,
     release_elicitation_submission,
     save_orchestration_step,
+    public_step_record,
     save_pending_turn_context,
     update_orchestration_run,
 )
@@ -159,6 +168,9 @@ from functions_orchestration_schema import (
     apply_plan_edits,
     normalize_elicitation,
     summarize_plan,
+    build_failure,
+    failure_explanation,
+    safe_failure,
 )
 from functions_settings import get_settings, get_user_settings
 from functions_prompt_metadata import build_prompt_selection_metadata
@@ -402,7 +414,7 @@ def _authorize_context_conversation(conversation_id, user_id):
         )
     except CosmosResourceNotFoundError:
         raise ConversationContextError('That conversation could not be opened.') from None
-    if conversation.get('user_id') != user_id:
+    if conversation.get('user_id') != user_id or conversation.get('orchestration_deleted'):
         raise ConversationContextError('That conversation could not be opened.')
     return conversation
 
@@ -696,20 +708,23 @@ def _record_cited_documents(conversation_id, user_id, document_citations):
                   f"documents: {exc}", level=logging.WARNING)
         return
 
-    if conversation.get('user_id') != user_id:
+    if conversation.get('user_id') != user_id or conversation.get('orchestration_deleted'):
         return
 
     try:
         merge_cited_documents_into_conversation(conversation, document_citations)
         conversation['last_updated'] = _now_iso()
-        cosmos_conversations_container.upsert_item(conversation)
+        cosmos_conversations_container.replace_item(
+            item=conversation_id, body=conversation, etag=conversation['_etag'],
+            match_condition=MatchConditions.IfNotModified,
+        )
         invalidate_conversation_cache_for_item(conversation, reason="orchestration_completed")
     except Exception as exc:
         log_event(f"[ORCHESTRATION] Could not record cited documents: {exc}",
                   level=logging.WARNING)
 
 
-def _save_message(conversation_id, role, content, metadata=None, extra=None, message_id=None):
+def _save_message(conversation_id, role, content, metadata=None, extra=None, message_id=None, persist=None):
     """Write one message, returning its id.
 
     ``extra`` carries the citation fields an assistant message needs. They are top-level
@@ -730,7 +745,10 @@ def _save_message(conversation_id, role, content, metadata=None, extra=None, mes
         document['metadata'] = metadata
 
     try:
-        cosmos_messages_container.upsert_item(document)
+        if persist:
+            persist(document)
+        else:
+            cosmos_messages_container.upsert_item(document)
     except Exception as exc:
         log_event(
             f'[ORCHESTRATION] Could not save a {role} message.',
@@ -888,7 +906,7 @@ def _touch_conversation(conversation_id, user_id, title=None):
     except Exception:
         return None
 
-    if item.get('user_id') != user_id:
+    if item.get('user_id') != user_id or item.get('orchestration_deleted'):
         return None
 
     item['last_updated'] = _now_iso()
@@ -896,7 +914,10 @@ def _touch_conversation(conversation_id, user_id, title=None):
         item['title'] = _text(title, 80)
 
     try:
-        cosmos_conversations_container.upsert_item(item)
+        cosmos_conversations_container.replace_item(
+            item=conversation_id, body=item, etag=item['_etag'],
+            match_condition=MatchConditions.IfNotModified,
+        )
     except Exception as exc:
         log_event(f"[ORCHESTRATION] Could not touch a conversation: {exc}",
                   level=logging.WARNING)
@@ -925,7 +946,9 @@ def _run_summary_row(record):
         'created_at': record.get('created_at'),
         'started_at': record.get('started_at'),
         'completed_at': record.get('completed_at'),
-        'error': _text(record.get('error'), 400) or None,
+        'error': safe_failure(record['failure'])['message'] if record.get('failure') else (
+            'This run did not complete.' if record.get('error') else None
+        ),
         'user_message': _text(record.get('user_message'), 400),
         'user_message_id': record.get('user_message_id'),
         'assistant_message_id': record.get('assistant_message_id'),
@@ -939,6 +962,7 @@ def _run_summary_row(record):
             'mode': approval.get('mode'),
             'state': approval.get('state'),
         },
+        **public_execution_fields(record),
     }
 
 
@@ -963,6 +987,243 @@ def _run_detail_row(record):
             row['plan'].get('reasoning_adjustments'), record.get('reasoning_adjustments'),
         )
     return row
+
+
+def _validate_checkpoint_artifacts(artifacts, conversation_id, user_id):
+    _authorize_context_conversation(conversation_id, user_id)
+    for artifact in artifacts:
+        artifact_id = artifact.get('artifact_message_id') if isinstance(artifact, dict) else None
+        if not artifact_id:
+            return False
+        try:
+            message = cosmos_messages_container.read_item(item=artifact_id, partition_key=conversation_id)
+        except CosmosResourceNotFoundError:
+            return False
+        metadata = message.get('metadata') or {}
+        if (
+            message.get('conversation_id') != conversation_id or metadata.get('masked')
+            or metadata.get('deleted') or message.get('deleted')
+            or message.get('user_id', user_id) != user_id
+        ):
+            return False
+        expires = artifact.get('expires_at') or metadata.get('expires_at')
+        if expires:
+            try:
+                if datetime.fromisoformat(expires.replace('Z', '+00:00')) <= datetime.now(timezone.utc):
+                    return False
+            except (ValueError, TypeError):
+                return False
+    return True
+
+
+def _checkpoint_artifact_versions(artifacts, conversation_id, user_id):
+    if not _validate_checkpoint_artifacts(artifacts, conversation_id, user_id):
+        raise CheckpointError('context_unavailable')
+    return {
+        artifact['artifact_message_id']: fingerprint(cosmos_messages_container.read_item(
+            item=artifact['artifact_message_id'], partition_key=conversation_id,
+        ))
+        for artifact in artifacts
+    }
+
+
+def _validate_retry_context(record, user_id, settings, *, preparing=False):
+    """Rebuild the same authorized execution inputs without invoking a model."""
+    conversation_id = record['conversation_id']
+    snapshot = _conversation_context_for_run(record, user_id, settings)
+    seeds = record.get('seeds') or {}
+    resolve_elicitation_references(seeds.get('elicitation_references') or [], user_id, conversation_id, settings=settings)
+    identity = _request_identity(user_id, seeded_agent=seeds.get('agent'))
+    agents = resolve_agent_catalog(
+        user_id, seeds=seeds, settings=settings, user_groups=seeds.get('active_group_ids') or None,
+    ) if identity.get('user_enable_agents', True) else []
+    actions = resolve_action_catalog(
+        user_id, seeds=seeds, settings=settings, user_groups=seeds.get('active_group_ids') or None,
+    )
+    allowed_urls = revision_allowed_urls(record)
+    required = {step['capability_id'] for step in record['plan'].get('steps') or [] if step.get('enabled', True)}
+    available = set(resolve_available_capability_ids(
+        settings, allowed_ids=settings.get('chat_orchestration_enabled_capabilities'), candidate_ids=required,
+        request_context=_capability_request_context(
+            user_id, identity, record.get('user_message'), agents, actions, allowed_user_urls=allowed_urls,
+        ),
+    ))
+    if required - available:
+        raise CheckpointError('context_unavailable')
+    _validate_turn_memory_context(record, user_id, conversation_id)
+    memory = load_orchestration_memory(
+        user_id, _authorize_context_conversation(conversation_id, user_id),
+        build_elicitation_user_request(record.get('resolved_message') or record.get('user_message'), record.get('answered_questions')),
+        settings=settings, seeds=seeds, expected_audience=record.get('memory_audience'),
+    )
+    model = resolve_orchestration_model(settings, user_id=user_id, seeds=seeds, identity_context=identity)
+    try:
+        context = RunContext(
+            run_id=record['id'], plan_id=record['plan'].get('plan_id'),
+            conversation_id=conversation_id, user_id=user_id,
+            user_message=record.get('user_message'), user_message_id=record.get('user_message_id'),
+            answered_questions=record.get('answered_questions') or [],
+            elicitation_references=seeds.get('elicitation_references') or [],
+            selected_document_ids=seeds.get('document_ids') or [],
+            original_seeds=record.get('original_seeds') or {},
+            resolved_message=record.get('resolved_message') or record.get('user_message'),
+            conversation_context=snapshot, context_message_ids=(record.get('request_resolution') or {}).get('message_ids'),
+            allowed_user_urls=allowed_urls, memory_context=memory, doc_scope=seeds.get('doc_scope') or 'all',
+            tags=seeds.get('tags') or None, document_filter_mode=seeds.get('document_filter_mode') or None,
+            active_group_ids=seeds.get('active_group_ids') or None,
+            active_group_id=(seeds.get('active_group_ids') or [None])[0],
+            active_public_workspace_id=(seeds.get('active_public_workspace_ids') or [None])[0],
+            active_public_workspace_ids=seeds.get('active_public_workspace_ids') or None,
+            agent_catalog=agents, action_catalog=actions, user_enable_agents=identity.get('user_enable_agents', True),
+            user_roles=identity.get('user_roles'), user_email=identity.get('user_email'),
+            gpt_model=model.deployment, model_context={
+                'model_id': model.model_id, 'endpoint_id': model.endpoint_id,
+                'provider': model.provider, 'model_deployment': model.deployment,
+            },
+            agent_execution_identity=capture_execution_identity(user_id, conversation_id),
+        )
+        context.validate_checkpoint_artifacts = lambda artifacts: _validate_checkpoint_artifacts(artifacts, conversation_id, user_id)
+        context.checkpoint_artifact_versions = lambda artifacts: _checkpoint_artifact_versions(artifacts, conversation_id, user_id)
+        return validate_resume(
+            record, context, settings,
+            lambda: _authorize_context_conversation(conversation_id, user_id),
+            source_run_id=record['id'] if preparing else None,
+        )
+    finally:
+        model.close()
+
+
+def _finalize_execution(record, result, error, context, lease, answer_model, research_model, run_token_usage):
+    """Persist every terminal explanation on the worker, even after transport loss."""
+    current = lease.read()
+    result = result if isinstance(result, dict) else {}
+    if not error and result:
+        try:
+            _conversation_context_for_run(record, record['user_id'], get_settings())
+            _validate_turn_memory_context(record, record['user_id'], record['conversation_id'])
+            document_ids = set(getattr(context, 'documents_touched', []) or [])
+            document_ids.update(
+                item['document_id'] for item in result.get('citations') or []
+                if isinstance(item, dict) and item.get('document_id')
+            )
+            if document_ids:
+                manifest = resolve_context_source_manifest(
+                    context, sorted(document_ids), settings=get_settings(), user_id=record['user_id'],
+                )
+                authorized = {
+                    item.get('document_id') for item in manifest if item.get('authorization_status') == 'authorized'
+                }
+                if document_ids - authorized:
+                    raise CheckpointError('context_unavailable')
+            if result.get('artifacts') and not _validate_checkpoint_artifacts(
+                result['artifacts'], record['conversation_id'], record['user_id'],
+            ):
+                raise CheckpointError('context_unavailable')
+        except Exception:
+            error = CheckpointError('context_unavailable')
+    if error or not result:
+        failure = safe_failure(error.failure) if isinstance(error, CheckpointError) else build_failure(
+            'context_unavailable' if isinstance(error, (ConversationContextError, OrchestrationMemoryError, PermissionError)) else 'execution_interrupted'
+        )
+        failures = list(getattr(context, 'failures', [])) + [failure]
+        result = {
+            'status': 'failed', 'outcome': 'failed', 'failure': failures[0], 'failures': failures,
+            'message': failure_explanation(failures), 'citations': [], 'artifacts': [],
+            'token_usage': getattr(context, 'token_usage', {}),
+        }
+        if isinstance(error, CheckpointError) and not any(
+            step.get('status') == 'running' for step in current.get('execution_steps') or []
+        ):
+            current = lease.update({'recovery_blocked_code': error.code})
+    failures = [safe_failure(value) for value in result.get('failures') or []]
+    failure = failures[0] if failures else None
+    status = result.get('status') if result.get('status') in ('completed', 'failed', 'cancelled') else 'failed'
+    outcome = result.get('outcome') or status
+    answer = result.get('message') or failure_explanation(failures, cancelled=status == 'cancelled')
+    combined_usage = _combined_token_usage(run_token_usage, result.get('token_usage'))
+    reasoning = build_model_reasoning_metadata(answer_model)
+    reasoning['reasoning_adjustments'] = merge_reasoning_adjustments(
+        record['plan'].get('reasoning_adjustments'), reasoning.get('reasoning_adjustments'),
+        build_model_reasoning_metadata(research_model, 'planner').get('reasoning_adjustments')
+        if research_model is not answer_model else [],
+    )
+    steps = deepcopy(current.get('execution_steps') or [])
+    for step in steps:
+        if step.get('status') == 'running':
+            step.update({'status': 'failed', 'failure': failure or build_failure('execution_interrupted')})
+    updates = {
+        'status': status, 'outcome': outcome, 'failure': failure, 'failures': failures,
+        'error': failure['message'] if failure else None, 'completed_at': _now_iso(),
+        'execution_steps': steps, 'token_usage': combined_usage,
+        'reasoning_adjustments': reasoning['reasoning_adjustments'],
+    }
+    current = lease.update(updates)
+    # The future released state is what both the saved message and done frame
+    # describe. The live lease remains held until message persistence finishes.
+    message_id = f"assistant_orchestration_{fingerprint(record['id'])[:40]}"
+    public = public_execution_fields({
+        **current, 'execution_lease': None, 'finalization_status': 'saved',
+        'assistant_message_id': message_id, 'message_saved': True,
+    })
+    summary = summarize_plan(record['plan'])
+    summary.update({'status': status, 'capabilities_used': list(result.get('capabilities_used') or [])})
+    documents, web, tools = _partition_citations(result.get('citations'))
+    saved = False
+    try:
+        lease.read()
+        _authorize_context_conversation(record['conversation_id'], record['user_id'])
+        persisted_id = _save_message(
+            record['conversation_id'], 'assistant', answer, message_id=message_id,
+            persist=lease.publish_message,
+            metadata={
+                'orchestration': {
+                    'run_id': record['id'], 'turn_id': record.get('turn_id'),
+                    'plan_summary': summary, **public,
+                }, 'token_usage': combined_usage, **reasoning,
+            },
+            extra={
+                **answer_model.metadata(), **reasoning, 'hybrid_citations': documents,
+                'web_search_citations': web, 'agent_citations': tools,
+                'generated_artifacts': result.get('artifacts') or [],
+                'augmented': bool(documents or web or tools),
+            },
+        )
+        if persisted_id != message_id:
+            raise CheckpointError('message_not_saved')
+        saved = True
+        lease.update({'assistant_message_id': message_id, 'message_saved': True, 'finalization_status': 'saved'})
+        _touch_conversation(record['conversation_id'], record['user_id'])
+        _record_cited_documents(record['conversation_id'], record['user_id'], documents)
+    except Exception as exc:
+        log_event(
+            '[ORCHESTRATION_RUNS] Terminal message publication failed.',
+            extra={'run_id': record['id'], 'error_type': type(exc).__name__}, level=logging.ERROR,
+        )
+        if not saved:
+            persistence_failure = build_failure('message_not_saved')
+            failures.append(persistence_failure)
+            failure = failures[0]
+            status, outcome = 'failed', 'failed'
+            public['recovery']['eligible'] = False
+            public['recovery'].update({'reason_code': 'message_not_saved', 'message': persistence_failure['message']})
+            lease.update({
+                'message_saved': False, 'recovery_blocked_code': 'message_not_saved',
+                'finalization_status': 'failed',
+                'status': status, 'outcome': outcome, 'failure': failure, 'failures': failures,
+                'error': persistence_failure['message'],
+            })
+    finalized = lease.close(release=True)
+    public = public_execution_fields(finalized)
+    frame = build_run_done_event(
+        record['conversation_id'], message_id=message_id if saved else None, run_id=record['id'],
+        turn_id=record.get('turn_id'), full_content=answer, citations=documents, web_citations=web,
+        agent_citations=tools, artifacts=result.get('artifacts'), plan_summary=summary,
+        status=status, outcome=outcome, attempt_index=public['attempt_index'],
+        retry_of_run_id=public['retry_of_run_id'], failure=failure, failures=failures,
+        recovery=public['recovery'], message_saved=saved,
+        finalization_status=public.get('finalization_status'), **answer_model.metadata(), **reasoning,
+    )
+    return ([build_content_event(answer)] if saved else [build_error_event(build_failure('message_not_saved')['message'], record['conversation_id'])]) + [frame]
 
 
 def _plan_edit_identity(data, settings):
@@ -1661,6 +1922,43 @@ def register_route_backend_orchestration(bp):
         streamed.call_on_close(lambda: release_plan_revision(claim))
         return streamed
 
+    @bp.route("/api/v2/orchestration/runs/<run_id>/retry", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def orchestration_retry(run_id):
+        settings = get_settings()
+        if not _orchestration_enabled(settings):
+            return jsonify({'error': 'Chat orchestration is not enabled.'}), 403
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+        data = request.get_json(silent=True)
+        conversation_id = data.get('conversation_id') if isinstance(data, dict) else None
+        try:
+            child = prepare_retry(
+                run_id, user_id, data,
+                authorize=lambda: _authorize_context_conversation(conversation_id, user_id),
+                validate=lambda record: _validate_retry_context(record, user_id, settings, preparing=True),
+                message_container=cosmos_messages_container,
+            )
+            return jsonify({'run': _run_detail_row(child)}), 200
+        except RecoveryError as exc:
+            payload = {'error': exc.message, 'code': exc.code}
+            if exc.recovery:
+                payload['recovery'] = exc.recovery
+            if exc.current_run_id:
+                payload['current_run_id'] = exc.current_run_id
+            return jsonify(payload), exc.status_code
+        except (ConversationContextError, PermissionError, LookupError):
+            return jsonify({'error': 'Run not found.', 'code': 'not_found'}), 404
+        except Exception as exc:
+            log_event(
+                '[ORCHESTRATION_RUNS] Recovery preparation failed closed.',
+                extra={'run_id': run_id, 'error_type': type(exc).__name__}, level=logging.ERROR,
+            )
+            return jsonify({'error': 'Saved progress could not be verified. Please retry.', 'code': 'recovery_unavailable'}), 503
+
     @bp.route("/api/v2/orchestration/run", methods=["POST"])
     @swagger_route(security=get_auth_security())
     @login_required
@@ -1690,12 +1988,18 @@ def register_route_backend_orchestration(bp):
             return jsonify({'error': 'Run not found.'}), 404
 
         plan = record.get('plan') or {}
-        if record.get('status') in (PLAN_STATUS_RUNNING, PLAN_STATUS_COMPLETED):
+        if record.get('started_at') or record.get('status') in (PLAN_STATUS_RUNNING, PLAN_STATUS_COMPLETED):
             return jsonify({'error': 'This plan has already been run.', 'code': 'already_run'}), 409
 
         conversation_id = conversation_id or _text(record.get('conversation_id'))
         try:
             snapshot = _conversation_context_for_run(record, user_id, settings)
+            if record.get('retry_of_run_id'):
+                if data.get('edits'):
+                    raise CheckpointError('recovery_changed')
+                _validate_retry_context(record, user_id, settings)
+        except CheckpointError:
+            return jsonify({'error': 'Saved progress or access changed. Create a new plan.', 'code': 'recovery_unavailable'}), 409
         except ConversationContextError:
             return jsonify({
                 'error': 'Conversation context changed or is unavailable. Create a new plan.',
@@ -1858,6 +2162,22 @@ def register_route_backend_orchestration(bp):
             payload, status = _plan_edit_error(exc)
             return jsonify(payload), status
         plan = record['plan']
+        lease = ExecutionLease(
+            record, lambda: _authorize_context_conversation(conversation_id, user_id),
+            message_container=cosmos_messages_container,
+        )
+        try:
+            lease.start()
+        except Exception as exc:
+            close_models()
+            log_event(
+                '[ORCHESTRATION_RUNS] Execution publication guard could not be initialized.',
+                extra={'run_id': run_id, 'error_type': type(exc).__name__}, level=logging.ERROR,
+            )
+            return jsonify({
+                'error': 'Execution could not start because its durable status could not be saved.',
+                'code': 'recovery_unavailable', 'message_saved': False,
+            }), 503
 
         def generate():
             nonlocal worker_started
@@ -1891,33 +2211,26 @@ def register_route_backend_orchestration(bp):
                 frames.put(build_step_event(
                     event.get('step_id'), phase, _text(event.get('summary')),
                     event.get('step_index'), event.get('capability_id'),
+                    **{key: event[key] for key in (
+                        'failure', 'reused', 'reused_from_run_id', 'checkpoint_available',
+                    ) if key in event},
                 ))
                 if event.get('capability_id') == 'respond':
                     frames.put(build_synthesis_thought(
                         event.get('step_index') or 0,
-                        status='completed' if phase != 'running' else 'running',
+                        status=phase or 'running',
                     ))
                 else:
                     frames.put(build_step_thought(
                         step, event.get('step_index') or 0,
                         event.get('completed') or 0, event.get('total') or 1,
-                        status='running' if phase == 'running' else 'completed',
+                        status=phase or 'running',
                         summary=_text(event.get('summary')) or None,
                     ))
 
             def persist(record_type, payload):
-                try:
-                    if record_type == 'step':
-                        save_orchestration_step(run_id, payload)
-                    elif record_type == 'run':
-                        update_orchestration_run(
-                            run_id, user_id,
-                            {k: v for k, v in (payload or {}).items() if k != 'run_id'},
-                            conversation_id=conversation_id,
-                        )
-                except Exception as exc:
-                    log_event(f"[ORCHESTRATION] Progress not persisted: {exc}",
-                              level=logging.WARNING)
+                if record_type == 'run':
+                    lease.update({k: v for k, v in (payload or {}).items() if k != 'run_id'})
 
             def reload_memory_context():
                 nonlocal memory_context
@@ -1940,6 +2253,7 @@ def register_route_backend_orchestration(bp):
                 conversation_id=conversation_id,
                 user_id=user_id,
                 turn_index=record.get('turn_index') or 0,
+                attempt_index=record.get('attempt_index') or 1,
                 invoke_prompt=invoke_prompt,
                 planner_client=research_model.as_planner_client(),
                 planner_deployment=research_model.deployment,
@@ -1976,7 +2290,10 @@ def register_route_backend_orchestration(bp):
                 agent_execution_identity=agent_execution_identity,
             )
 
-            cancel_requested = _make_cancel_probe(run_id, user_id, conversation_id)
+            context.validate_checkpoint_artifacts = lambda artifacts: _validate_checkpoint_artifacts(artifacts, conversation_id, user_id)
+            context.checkpoint_artifact_versions = lambda artifacts: _checkpoint_artifact_versions(artifacts, conversation_id, user_id)
+            context.prompt_token_usage = run_token_usage
+            cancel_requested = lease.cancel_requested
             outcome = {}
 
             def worker():
@@ -1988,6 +2305,7 @@ def register_route_backend_orchestration(bp):
                         emit=emit,
                         cancel_requested=cancel_requested,
                         persist=persist,
+                        checkpoints=lambda ctx: ExecutionCheckpoints(record, ctx, settings, lease),
                     )
                 except Exception as exc:
                     outcome['error'] = exc
@@ -2000,7 +2318,24 @@ def register_route_backend_orchestration(bp):
                     # thrown worker cannot leave the response waiting on a queue nothing
                     # will ever write to again.
                     try:
-                        close_models()
+                        try:
+                            for frame in _finalize_execution(
+                                record, outcome.get('result'), outcome.get('error'), context, lease,
+                                answer_model, research_model, run_token_usage,
+                            ):
+                                frames.put(frame)
+                        except Exception as exc:
+                            log_event(
+                                '[ORCHESTRATION_RUNS] Execution finalization could not be committed.',
+                                extra={'run_id': run_id, 'error_type': type(exc).__name__}, level=logging.ERROR,
+                            )
+                            frames.put(build_error_event(
+                                'The execution status could not be saved. Reload the run to check its durable state.',
+                                conversation_id,
+                            ))
+                        finally:
+                            lease.close()
+                            close_models()
                     finally:
                         frames.put(None)
 
@@ -2025,121 +2360,12 @@ def register_route_backend_orchestration(bp):
 
             thread.join(timeout=RUN_JOIN_TIMEOUT_SECONDS)
 
-            failed_result = outcome.get('result') or {}
-            reasoning_metadata = build_model_reasoning_metadata(answer_model)
-            reasoning_metadata['reasoning_adjustments'] = merge_reasoning_adjustments(
-                plan.get('reasoning_adjustments'), reasoning_metadata.get('reasoning_adjustments'),
-                build_model_reasoning_metadata(research_model, 'planner').get('reasoning_adjustments')
-                if research_model is not answer_model else [],
-            )
-            if (
-                'error' in outcome or 'result' not in outcome
-                or failed_result.get('status') == PLAN_STATUS_FAILED
-            ):
-                error_message = (
-                    'Conversation context changed. Create a new plan.'
-                    if isinstance(outcome.get('error'), ConversationContextError)
-                    else 'The run could not be completed.'
-                )
-                try:
-                    update_orchestration_run(run_id, user_id, {
-                        'status': PLAN_STATUS_FAILED,
-                        'error': error_message,
-                        'completed_at': _now_iso(),
-                        'reasoning_adjustments': reasoning_metadata['reasoning_adjustments'],
-                        'token_usage': _combined_token_usage(
-                            run_token_usage, failed_result.get('token_usage'),
-                        ),
-                    }, conversation_id=conversation_id)
-                except AzureError as exc:
-                    log_event(
-                        '[ORCHESTRATION] Could not persist a failed run.',
-                        level=logging.ERROR, extra={'error_type': type(exc).__name__},
-                    )
-                yield build_error_event(error_message, conversation_id)
-                return
-
-            result = outcome['result']
-            combined_usage = _combined_token_usage(run_token_usage, result.get('token_usage'))
-            answer = _text(result.get('message'))
-            if (result.get('reauthorization') or {}).get('reason') == 'elicitation_context_unavailable':
-                yield build_error_event(
-                    'Accepted answer context is no longer available. Please update the answer or retry.',
-                    conversation_id,
-                )
-                return
-            if result.get('status') == PLAN_STATUS_CANCELLED:
-                yield build_cancelled_event(conversation_id, run_id, answer)
-                return
-
-            summary = summarize_plan(plan)
-            summary['status'] = result.get('status')
-            summary['capabilities_used'] = list(result.get('capabilities_used') or [])
-
-            # Everything the run gathered, split the way an assistant message carries it.
-            document_citations, web_citations, tool_citations = _partition_citations(result.get('citations'))
-
-            # The answer is an ordinary assistant message. Written before the terminal
-            # frame so that a client which reloads the moment it arrives finds the answer
-            # in the conversation rather than an empty turn where one just streamed.
-            message_id = _save_message(
-                conversation_id, 'assistant', answer,
-                metadata={
-                    'orchestration': {
-                        'run_id': run_id,
-                        'turn_id': record.get('turn_id'),
-                        'plan_summary': summary,
-                    },
-                    'token_usage': combined_usage,
-                    **reasoning_metadata,
-                },
-                extra={
-                    **answer_model.metadata(),
-                    **reasoning_metadata,
-                    'hybrid_citations': document_citations,
-                    'web_search_citations': web_citations,
-                    'agent_citations': tool_citations,
-                    'generated_artifacts': result.get('artifacts') or [],
-                    'augmented': bool(document_citations or web_citations or tool_citations),
-                },
-            ) if answer else None
-
-            if answer:
-                _touch_conversation(conversation_id, user_id)
-                # What the Documents drawer reads. The drawer works from the conversation's
-                # used-document list rather than from the message's citations, so citing a
-                # document is not enough on its own to make it appear there.
-                _record_cited_documents(conversation_id, user_id, document_citations)
-                yield build_content_event(answer)
-
-            try:
-                update_orchestration_run(run_id, user_id, {
-                    'assistant_message_id': message_id,
-                    'token_usage': combined_usage,
-                    'reasoning_adjustments': reasoning_metadata['reasoning_adjustments'],
-                }, conversation_id=conversation_id)
-            except Exception:
-                # The answer is already saved and streamed; failing to cross-reference it
-                # is not worth failing the run over.
-                pass
-
-            answer_metadata = {**answer_model.metadata(), **reasoning_metadata}
-            yield build_run_done_event(
-                conversation_id,
-                message_id=message_id,
-                run_id=run_id,
-                full_content=answer,
-                citations=document_citations,
-                web_citations=web_citations,
-                agent_citations=tool_citations,
-                artifacts=result.get('artifacts'),
-                plan_summary=summary,
-                status=result.get('status') or PLAN_STATUS_COMPLETED,
-                **answer_metadata,
-            )
-
         response = _sse(generate())
-        response.call_on_close(lambda: close_models() if not worker_started else None)
+        def close_unstarted():
+            if not worker_started:
+                lease.close()
+                close_models()
+        response.call_on_close(close_unstarted)
         return response
 
     @bp.route("/api/v2/orchestration/cancel/<run_id>", methods=["POST"])
@@ -2164,10 +2390,11 @@ def register_route_backend_orchestration(bp):
             return jsonify({'error': 'Run not found.'}), 404
 
         try:
-            update_orchestration_run(run_id, user_id, {
-                'cancellation_requested_at': _now_iso(),
-                'cancellation_requested_by': user_id,
-            }, conversation_id=conversation_id or record.get('conversation_id'))
+            conversation_id = conversation_id or record.get('conversation_id')
+            request_cancellation(
+                run_id, user_id, conversation_id,
+                lambda: _authorize_context_conversation(conversation_id, user_id),
+            )
         except Exception as exc:
             log_event(f"[ORCHESTRATION] Could not record a cancellation: {exc}",
                       level=logging.ERROR)
@@ -2203,7 +2430,11 @@ def register_route_backend_orchestration(bp):
         include_plan = _text(request.args.get('include_plan')).lower() in ('1', 'true', 'yes')
 
         try:
-            runs = list_conversation_runs(conversation_id, user_id, limit=limit)
+            _authorize_context_conversation(conversation_id, user_id)
+            runs = list_conversation_runs(conversation_id, user_id, limit=limit, strict=True)
+            runs = [reconcile_checkpoints(run, lambda: _authorize_context_conversation(conversation_id, user_id)) for run in runs]
+        except ConversationContextError:
+            return jsonify({'error': 'Conversation not found.'}), 404
         except Exception as exc:
             log_event(f"[ORCHESTRATION] Could not list runs: {exc}", level=logging.ERROR)
             return jsonify({'error': 'The run history could not be loaded.'}), 500
@@ -2236,7 +2467,7 @@ def register_route_backend_orchestration(bp):
 
         try:
             record = get_orchestration_run(
-                run_id, user_id, conversation_id=conversation_id or None
+                run_id, user_id, conversation_id=conversation_id or None, strict=True,
             )
         except Exception as exc:
             log_event(f"[ORCHESTRATION] Could not read run {run_id}: {exc}",
@@ -2246,6 +2477,15 @@ def register_route_backend_orchestration(bp):
         if not record:
             return jsonify({'error': 'Run not found.'}), 404
 
+        try:
+            _authorize_context_conversation(record['conversation_id'], user_id)
+            record = reconcile_checkpoints(
+                record, lambda: _authorize_context_conversation(record['conversation_id'], user_id),
+            )
+        except ConversationContextError:
+            return jsonify({'error': 'Run not found.'}), 404
+        except CheckpointError:
+            return jsonify({'error': 'Saved progress could not be verified.', 'code': 'recovery_unavailable'}), 503
         return jsonify({'run': _run_detail_row(record)}), 200
 
     @bp.route("/api/v2/orchestration/runs/<run_id>/steps", methods=["GET"])
@@ -2260,7 +2500,25 @@ def register_route_backend_orchestration(bp):
 
         conversation_id = _text(request.args.get('conversation_id'))
         try:
-            steps = list_run_steps(run_id, user_id=user_id, conversation_id=conversation_id)
+            record = get_orchestration_run(run_id, user_id, conversation_id=conversation_id, strict=True)
+            if not record:
+                return jsonify({'error': 'Run not found.'}), 404
+            _authorize_context_conversation(record['conversation_id'], user_id)
+            steps = list_run_steps(run_id, user_id=user_id, conversation_id=conversation_id, strict=True)
+            reconciled = reconcile_checkpoints(record, lambda: _authorize_context_conversation(record['conversation_id'], user_id))
+            committed = {
+                step['step_id']: step for step in reconciled.get('execution_steps') or []
+                if step.get('status') == 'completed' and step.get('checkpoint_available')
+            }
+            steps = [public_step_record(committed[step['step_id']]) if step.get('step_id') in committed else step for step in steps]
+            listed = {step.get('step_id') for step in steps}
+            steps.extend(
+                public_step_record({**step, 'run_id': run_id})
+                for step_id, step in committed.items() if step_id not in listed
+            )
+            steps.sort(key=lambda step: step.get('step_index', 0))
+        except ConversationContextError:
+            return jsonify({'error': 'Run not found.'}), 404
         except Exception as exc:
             log_event(f"[ORCHESTRATION] Could not list run steps: {exc}", level=logging.ERROR)
             return jsonify({'error': 'The run steps could not be loaded.'}), 500

--- a/application/v2_ui/src/components/chat/MessageActions.tsx
+++ b/application/v2_ui/src/components/chat/MessageActions.tsx
@@ -617,7 +617,7 @@ export function MessageActions({
                     )
                 ) : (
                     <IconButton
-                        label="Retry"
+                        label={message.metadata?.orchestration ? 'Review orchestration recovery' : 'Retry'}
                         onClick={() => void retryMessage(message.id)}
                         disabled={streaming}
                     >

--- a/application/v2_ui/src/components/chat/MessageList.tsx
+++ b/application/v2_ui/src/components/chat/MessageList.tsx
@@ -28,6 +28,7 @@ import { AssistantMarkdown } from './AssistantMarkdown';
 import { ChatFilePreview } from './ChatFilePreview';
 import { GeneratedArtifactCard } from './GeneratedArtifactCard';
 import { MessageActions } from './MessageActions';
+import { OrchestrationMessageRecovery } from './OrchestrationRecoveryNotice';
 import { MessageInspector, type InspectorSection } from './MessageInspector';
 import { ThoughtsList, ThoughtsProgressCard } from './ThoughtsList';
 import { OrchestrationPlanCard } from './OrchestrationPlanCard';
@@ -605,6 +606,10 @@ function MessageBubbleInner({
                             </p>
                         )}
                         <ReasoningAdjustmentNotice adjustments={message.metadata?.reasoning_adjustments} />
+                        <OrchestrationMessageRecovery
+                            conversationId={message.conversation_id}
+                            metadata={message.metadata?.orchestration}
+                        />
                         {/* Inside the bubble, because a generated file belongs to the reply
                             that produced it rather than sitting loose in the thread. */}
                         {artifacts.map((artifact, index) => (

--- a/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
@@ -1,5 +1,6 @@
 // OrchestrationPlanCard.tsx
 import { ReasoningAdjustmentNotice } from './ReasoningAdjustmentNotice';
+import { OrchestrationRecoveryNotice } from './OrchestrationRecoveryNotice';
 // The plan, inline in the thread, kept deliberately small.
 //
 // Orchestration turns the composer inside out: instead of the user picking documents, a model and
@@ -122,6 +123,11 @@ export function OrchestrationPlanCard({
     const inFlightMap = useOrchestrationStore((state) => state.inFlight);
     const historyMap = useOrchestrationStore((state) => state.history);
     const setDrawerMode = useChatStore((state) => state.setDrawerMode);
+    const hasSavedNotice = useChatStore((state) => state.messages.some((message) => {
+        const metadata = message.metadata?.orchestration;
+        return metadata && typeof metadata === 'object' && 'run_id' in metadata
+            && metadata.run_id === plan?.run_id;
+    }));
 
     const editedPlan = useMemo(
         () => (plan ? applyPlanEdits(plan, edits) : null),
@@ -198,8 +204,10 @@ export function OrchestrationPlanCard({
     //
     // This is why the card renders from the store rather than from message markdown: there
     // is nothing to clean up when it stops being relevant, it simply stops rendering.
-    if (historyEntry && !runInFlight) {
-        return null;
+    if ((historyEntry || isPlanTerminal(plan)) && !runInFlight) {
+        if (hasSavedNotice) return null;
+        return <OrchestrationRecoveryNotice conversationId={conversationId}
+            runId={plan.run_id} plan={plan} status={plan.status} />;
     }
 
     // Running: a compact progress line. The full step list is a click away in the drawer, so this
@@ -219,6 +227,8 @@ export function OrchestrationPlanCard({
         return (
             <div className="my-3 rounded-2xl border border-edge-strong bg-surface-sunken px-3 py-2">
                 <ReasoningAdjustmentNotice adjustments={plan.reasoning_adjustments} />
+                <OrchestrationRecoveryNotice conversationId={conversationId}
+                    runId={plan.run_id} plan={plan} status={plan.status} />
                 <div className="flex items-center gap-2 text-sm">
                     <Loader2 size={15} className="shrink-0 animate-spin text-accent" />
                     <span className="min-w-0 flex-1 truncate text-text-1" title={summary.intent_summary}>

--- a/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
@@ -22,7 +22,7 @@ import {
     type StepRuntimeMap,
     type TrackedRun,
 } from '../../stores/orchestrationStore';
-import { fetchOrchestrationRun, fetchRunSteps, type OrchestrationPlan } from '../../lib/orchestration';
+import { fetchOrchestrationRun, fetchRunSteps, normalizeOrchestrationAttempt, type OrchestrationPlan } from '../../lib/orchestration';
 import { normalizePlan } from '../../lib/orchestrationPlan';
 import { openOrchestrationPlanEditor } from '../../lib/orchestrationController';
 import { GlassButton } from '../ui/primitives';
@@ -87,6 +87,7 @@ export function OrchestrationPlanPanel() {
     );
     const inFlightMap = useOrchestrationStore((state) => state.inFlight);
     const pinRun = useOrchestrationStore((state) => state.pinRun);
+    const recoveryTarget = useOrchestrationStore((state) => state.recoveryTarget);
 
     const [view, setView] = useState<PanelView>('run');
     const [pinned, setPinned] = useState<PinnedRun | null>(null);
@@ -171,12 +172,18 @@ export function OrchestrationPlanPanel() {
                     return;
                 }
                 const store = useOrchestrationStore.getState();
+                store.updateRunRecovery(runId, {
+                    ...normalizeOrchestrationAttempt(run), plan, status: run?.status, detailLoaded: true,
+                });
                 const current = selectPlan(store, activeConversationId, turnId);
                 if (current && (current.run_id !== runId
                     || selectCanEditPlan(store, activeConversationId, turnId))) {
                     const runtime: StepRuntimeMap = {};
                     for (const step of steps) {
-                        runtime[step.step_id] = { status: step.status ?? 'pending', summary: step.summary ?? '' };
+                        runtime[step.step_id] = {
+                            status: step.status ?? 'pending', summary: step.summary ?? '',
+                            reused: step.reused === true, failure: step.failure,
+                        };
                     }
                     setArchivedPreview({ runId, plan, runtime });
                 } else {
@@ -217,6 +224,20 @@ export function OrchestrationPlanPanel() {
     };
 
     const showJumpBar = Boolean(pinned && liveRun && liveRun.turnId !== shownTurnId);
+
+    useEffect(() => {
+        if (!recoveryTarget || recoveryTarget.conversationId !== activeConversationId) return;
+        let cancelled = false;
+        setView('run');
+        void fetchOrchestrationRun(recoveryTarget.runId, { conversationId: activeConversationId }).then((run) => {
+            if (cancelled || !run?.turn_id) return;
+            setPinned({ runId: recoveryTarget.runId, turnId: run.turn_id });
+            loadArchivedRun(run.turn_id, recoveryTarget.runId);
+        }).catch(() => {
+            if (!cancelled) setLoadError('The saved attempt could not be loaded. Please try again.');
+        });
+        return () => { cancelled = true; };
+    }, [recoveryTarget, activeConversationId]);
 
     return (
         <div className="flex h-full flex-col">

--- a/application/v2_ui/src/components/chat/OrchestrationRecoveryNotice.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRecoveryNotice.tsx
@@ -1,0 +1,203 @@
+// OrchestrationRecoveryNotice.tsx
+import { useEffect, useRef, useState } from 'react';
+import { GlassButton } from '../ui/primitives';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { useChatStore } from '../../stores/chatStore';
+import { useOrchestrationStore } from '../../stores/orchestrationStore';
+import {
+    cancelOrchestration,
+    loadOrchestrationRecovery,
+    openOrchestrationRecovery,
+    reconcileOrchestrationRun,
+    retryOrchestrationRun,
+    runPreparedOrchestrationRetry,
+} from '../../lib/orchestrationController';
+import { normalizeOrchestrationAttempt, type OrchestrationPlan, type PlanStatus } from '../../lib/orchestration';
+
+function RecoveryConfirmation({
+    busy, onConfirm, onClose,
+}: { busy?: boolean; onConfirm: () => void; onClose: () => void }) {
+    const contentRef = useRef<HTMLParagraphElement>(null);
+    useEffect(() => {
+        const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const dialog = contentRef.current?.closest('[role="dialog"]');
+        const oldOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        dialog?.querySelector<HTMLElement>('button')?.focus();
+        const trapTab = (event: KeyboardEvent) => {
+            if (event.key !== 'Tab') return;
+            const buttons = Array.from(dialog?.querySelectorAll<HTMLElement>('button:not([disabled])') ?? []);
+            const first = buttons[0];
+            const last = buttons[buttons.length - 1];
+            if (!dialog?.contains(document.activeElement)
+                || (event.shiftKey && document.activeElement === first)
+                || (!event.shiftKey && document.activeElement === last)) {
+                event.preventDefault();
+                (event.shiftKey ? last : first)?.focus();
+            }
+        };
+        document.addEventListener('keydown', trapTab);
+        return () => {
+            document.removeEventListener('keydown', trapTab);
+            document.body.style.overflow = oldOverflow;
+            if (previous?.isConnected) previous.focus();
+        };
+    }, []);
+    return (
+        <ConfirmDialog
+            title="Retry this failed step?"
+            description="The failed agent or action step may already have performed actions in an external service. Retrying it could repeat actions inside that step."
+            confirmLabel="Confirm retry"
+            tone="primary"
+            busy={busy}
+            onConfirm={onConfirm}
+            onClose={() => { if (!busy) onClose(); }}
+        >
+            <p ref={contentRef} className="text-sm text-text-2">
+                Previously completed plan steps will not be repeated. Only incomplete work listed for retry will execute.
+            </p>
+        </ConfirmDialog>
+    );
+}
+
+export function OrchestrationRecoveryNotice({
+    conversationId,
+    runId,
+    metadata,
+    plan,
+    status,
+}: {
+    conversationId: string;
+    runId: string;
+    metadata?: unknown;
+    plan?: OrchestrationPlan;
+    status?: PlanStatus;
+}) {
+    const saved = useOrchestrationStore((state) => state.runRecovery[runId]);
+    const streaming = useChatStore((state) => state.streaming);
+    const inFlight = useOrchestrationStore((state) => state.inFlight);
+    const [confirmationVersion, setConfirmationVersion] = useState<string | null>(null);
+    const attempt = saved ?? normalizeOrchestrationAttempt(metadata);
+    const outcome = attempt.outcome ?? saved?.status ?? status;
+    const failed = outcome === 'failed' || outcome === 'partial' || outcome === 'cancelled';
+    const newer = attempt.recovery?.current_run_id || attempt.latest_attempt_run_id;
+    const previousRunId = attempt.retry_of_run_id;
+    const relevant = failed || saved?.transportUnknown || saved?.error
+        || Boolean(newer && newer !== runId) || Boolean(attempt.retry_of_run_id);
+    const currentPlan = saved?.plan ?? plan;
+    const recovery = attempt.recovery;
+
+    useEffect(() => {
+        if (!runId || saved?.detailLoaded || (!relevant && outcome)) return;
+        let mounted = true;
+        void loadOrchestrationRecovery(conversationId, runId).catch(() => {
+            if (mounted) useOrchestrationStore.getState().updateRunRecovery(runId, {
+                error: 'Recovery details could not be loaded. The previous result has been kept. Check saved status before retrying.',
+            });
+        });
+        return () => { mounted = false; };
+    }, [conversationId, runId, saved?.detailLoaded, Boolean(relevant), outcome]);
+
+    if (!runId || !relevant) return null;
+    const active = Object.values(inFlight).some((run) => run.conversationId === conversationId);
+    const retryAllowed = failed && recovery?.eligible && recovery.expected_version
+        && (!newer || newer === runId) && !saved?.transportUnknown;
+    const retry = async (confirmedVersion?: string) => {
+        const result = await retryOrchestrationRun(conversationId, runId, confirmedVersion);
+        setConfirmationVersion(result.confirmationRequired && result.version ? result.version : null);
+    };
+    const titleFor = (stepId: string) => currentPlan?.steps.find((step) => step.step_id === stepId)?.title || stepId;
+
+    return (
+        <section
+            aria-label="Orchestration recovery"
+            className="alert mt-3 space-y-2 rounded-xl border border-edge bg-surface-sunken p-3 text-xs text-text-2"
+        >
+            <p role="status" className="font-medium text-text-1">
+                {saved?.transportUnknown ? 'Checking execution status'
+                    : outcome === 'partial' ? 'Partially completed'
+                    : outcome === 'failed' ? 'The plan could not complete'
+                    : outcome === 'cancelled' ? 'This attempt was stopped' : 'Saved execution attempt'}
+                {attempt.attempt_index ? ` - Attempt ${attempt.attempt_index}` : ''}
+            </p>
+            {attempt.failure?.message ? <p>{attempt.failure.message}</p> : null}
+            {saved?.error ? <p role="alert">{saved.error}</p> : null}
+            {failed && !saved?.transportUnknown ? (
+                <p>{recovery?.message || (newer && newer !== runId
+                    ? 'A newer execution attempt already exists. Review its saved result.'
+                    : recovery?.eligible
+                    ? 'Resume the saved plan without repeating completed plan steps.'
+                    : 'This historical attempt has no verified recovery checkpoint. It cannot be resumed; start a new plan deliberately if needed.')}</p>
+            ) : null}
+            {failed && recovery?.reused_step_ids.length ? (
+                <p><strong>Reuse saved results:</strong> {recovery.reused_step_ids.map(titleFor).join(', ')}.</p>
+            ) : null}
+            {failed && recovery?.retry_step_ids.length ? (
+                <p><strong>Execute on retry:</strong> {recovery.retry_step_ids.map(titleFor).join(', ')}.</p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+                {attempt.retry_of_run_id && (outcome === 'awaiting_approval' || outcome === 'approved') ? (
+                    <GlassButton size="sm" disabled={Boolean(saved?.busy || streaming || active)}
+                        onClick={() => void runPreparedOrchestrationRetry(conversationId, runId)}>
+                        Run prepared retry
+                    </GlassButton>
+                ) : null}
+                {retryAllowed ? (
+                    <GlassButton size="sm" disabled={Boolean(saved?.busy || streaming || active)}
+                        onClick={() => void retry()}>
+                        {saved?.busy ? 'Preparing retry...' : 'Retry from failed step'}
+                    </GlassButton>
+                ) : null}
+                {newer && newer !== runId ? (
+                    <GlassButton size="sm" variant="subtle"
+                        onClick={() => openOrchestrationRecovery(conversationId, newer)}>
+                        View current attempt
+                    </GlassButton>
+                ) : null}
+                {previousRunId ? (
+                    <GlassButton size="sm" variant="subtle"
+                        onClick={() => openOrchestrationRecovery(conversationId, previousRunId)}>
+                        View previous attempt
+                    </GlassButton>
+                ) : null}
+                <GlassButton size="sm" variant="ghost"
+                    onClick={() => openOrchestrationRecovery(conversationId, runId)}>
+                    Review saved attempt
+                </GlassButton>
+                {saved?.transportUnknown || saved?.error ? (
+                    <GlassButton size="sm" variant="subtle" disabled={saved.checking}
+                        onClick={() => void reconcileOrchestrationRun(conversationId, runId)}>
+                        Check saved status
+                    </GlassButton>
+                ) : null}
+                {saved?.transportUnknown && inFlight[runId] ? (
+                    <GlassButton size="sm" variant="ghost"
+                        onClick={() => void cancelOrchestration(conversationId, runId)}>
+                        Stop execution
+                    </GlassButton>
+                ) : null}
+            </div>
+            {confirmationVersion ? (
+                <RecoveryConfirmation
+                    busy={saved?.busy}
+                    onConfirm={() => void retry(confirmationVersion)}
+                    onClose={() => setConfirmationVersion(null)}
+                />
+            ) : null}
+        </section>
+    );
+}
+
+export function OrchestrationMessageRecovery({
+    conversationId, metadata,
+}: { conversationId: string; metadata: unknown }) {
+    const attempt = normalizeOrchestrationAttempt(metadata);
+    if (!attempt.run_id && (attempt.outcome === 'failed' || attempt.outcome === 'partial' || attempt.outcome === 'cancelled')) {
+        return <p role="status" className="alert mt-3 rounded-xl bg-surface-sunken p-3 text-xs text-text-2">
+            This historical orchestration message has no saved attempt identity. It cannot be resumed.
+        </p>;
+    }
+    return attempt.run_id ? (
+        <OrchestrationRecoveryNotice conversationId={conversationId} runId={attempt.run_id} metadata={metadata} />
+    ) : null;
+}

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -1,5 +1,6 @@
 // OrchestrationRunView.tsx
 import { ReasoningAdjustmentNotice } from './ReasoningAdjustmentNotice';
+import { OrchestrationRecoveryNotice } from './OrchestrationRecoveryNotice';
 // The full step list for one run or one pending plan, with the narrowing edits and live status.
 //
 // This is the detail the inline card deliberately omits. It reads the RAW plan, not the edited
@@ -314,6 +315,11 @@ export function OrchestrationRunView({
                             >
                                 {status}
                             </span>
+                            {stepRuntime[step.step_id]?.reused ? (
+                                <span className="rounded-full bg-ok-soft px-2 py-0.5 text-[11px] text-ok">
+                                    Reused saved result
+                                </span>
+                            ) : null}
                         </div>
 
                         {step.rationale ? (
@@ -482,6 +488,9 @@ export function OrchestrationRunView({
     return (
         <div className="space-y-3 p-3">
             <ReasoningAdjustmentNotice adjustments={plan.reasoning_adjustments} />
+            <OrchestrationRecoveryNotice
+                conversationId={conversationId} runId={plan.run_id} plan={plan} status={plan.status}
+            />
             {readOnly && !previewPlan ? (
                 <p className="flex items-center gap-1.5 rounded-lg border border-edge bg-surface-2 px-2 py-1.5 text-[11px] text-text-3">
                     <Archive size={12} className="shrink-0" />

--- a/application/v2_ui/src/lib/orchestration.ts
+++ b/application/v2_ui/src/lib/orchestration.ts
@@ -48,6 +48,116 @@ export type StepStatus =
     | 'skipped'
     | 'cancelled';
 
+export type OrchestrationOutcome = 'completed' | 'partial' | 'failed' | 'cancelled';
+export type OrchestrationFinalizationStatus = 'pending' | 'saved' | 'failed' | 'interrupted';
+
+export interface OrchestrationFailure {
+    code: string;
+    message: string;
+    step_id?: string;
+    capability_id?: string;
+    provider_status?: number;
+}
+
+export interface OrchestrationRecovery {
+    eligible: boolean;
+    reason_code: string | null;
+    message: string | null;
+    expected_version: string | null;
+    source_run_id: string;
+    current_run_id?: string;
+    retry_step_ids: string[];
+    reused_step_ids: string[];
+    requires_confirmation: boolean;
+}
+
+export interface OrchestrationAttempt {
+    run_id?: string;
+    turn_id?: string | null;
+    outcome?: OrchestrationOutcome;
+    failure?: OrchestrationFailure | null;
+    failures?: OrchestrationFailure[];
+    recovery?: OrchestrationRecovery;
+    attempt_index?: number;
+    retry_of_run_id?: string | null;
+    latest_attempt_run_id?: string;
+    finalization_status?: OrchestrationFinalizationStatus;
+    message_saved?: boolean;
+}
+
+function recordOf(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+export function normalizeOrchestrationFailure(value: unknown): OrchestrationFailure | null {
+    const data = recordOf(value);
+    if (typeof data.code !== 'string' || typeof data.message !== 'string') return null;
+    return {
+        code: data.code,
+        message: data.message,
+        ...(typeof data.step_id === 'string' ? { step_id: data.step_id } : {}),
+        ...(typeof data.capability_id === 'string' ? { capability_id: data.capability_id } : {}),
+        ...(typeof data.provider_status === 'number' ? { provider_status: data.provider_status } : {}),
+    };
+}
+
+export function normalizeOrchestrationRecovery(value: unknown): OrchestrationRecovery | undefined {
+    const data = recordOf(value);
+    if (typeof data.source_run_id !== 'string' || typeof data.eligible !== 'boolean') return undefined;
+    const ids = (value: unknown): string[] => Array.isArray(value)
+        ? value.filter((id): id is string => typeof id === 'string') : [];
+    return {
+        eligible: data.eligible,
+        source_run_id: data.source_run_id,
+        reason_code: typeof data.reason_code === 'string' ? data.reason_code : null,
+        message: typeof data.message === 'string' ? data.message : null,
+        expected_version: typeof data.expected_version === 'string' ? data.expected_version : null,
+        current_run_id: typeof data.current_run_id === 'string' ? data.current_run_id : undefined,
+        retry_step_ids: ids(data.retry_step_ids),
+        reused_step_ids: ids(data.reused_step_ids),
+        // Missing replay-safety information must never silently authorize external effects.
+        requires_confirmation: data.requires_confirmation !== false,
+    };
+}
+
+export function normalizeOrchestrationAttempt(value: unknown): OrchestrationAttempt {
+    const outer = recordOf(value);
+    const data = { ...recordOf(recordOf(outer.metadata).orchestration), ...outer };
+    const outcome = data.outcome;
+    const finalization = data.finalization_status;
+    return {
+        run_id: typeof data.run_id === 'string' ? data.run_id : undefined,
+        turn_id: typeof data.turn_id === 'string' ? data.turn_id : undefined,
+        outcome: outcome === 'completed' || outcome === 'partial' || outcome === 'failed' || outcome === 'cancelled'
+            ? outcome : undefined,
+        failure: normalizeOrchestrationFailure(data.failure),
+        failures: Array.isArray(data.failures)
+            ? data.failures.map(normalizeOrchestrationFailure).filter((value): value is OrchestrationFailure => value !== null) : [],
+        recovery: normalizeOrchestrationRecovery(data.recovery),
+        attempt_index: typeof data.attempt_index === 'number' ? data.attempt_index : undefined,
+        retry_of_run_id: typeof data.retry_of_run_id === 'string' ? data.retry_of_run_id : undefined,
+        latest_attempt_run_id: typeof data.latest_attempt_run_id === 'string' ? data.latest_attempt_run_id : undefined,
+        finalization_status: finalization === 'pending' || finalization === 'saved'
+            || finalization === 'failed' || finalization === 'interrupted' ? finalization : undefined,
+        message_saved: typeof data.message_saved === 'boolean' ? data.message_saved : undefined,
+    };
+}
+
+/** A terminal execution status can precede durable final-message publication. */
+export function isOrchestrationRunPending(run: OrchestrationAttempt & { status?: string | null }): boolean {
+    return run.status === 'running' || run.finalization_status === 'pending'
+        || run.recovery?.reason_code === 'execution_live';
+}
+
+export function orchestrationTerminalStatus(event: RunStreamEvent): 'completed' | 'failed' | 'cancelled' {
+    const outcome = normalizeOrchestrationAttempt(event).outcome;
+    if (event.status === 'failed' || outcome === 'failed' || outcome === 'partial' || event.error) return 'failed';
+    if (event.status === 'cancelled' || outcome === 'cancelled') return 'cancelled';
+    if (event.status === 'completed' || outcome === 'completed') return 'completed';
+    if (event.cancelled || event.canceled || event.type === 'cancelled' || event.type === 'canceled') return 'cancelled';
+    return 'completed';
+}
+
 /** How a plan is approved before it runs, from `APPROVAL_MODES`. */
 export type ApprovalMode = 'manual' | 'timed' | 'auto';
 
@@ -462,10 +572,13 @@ export interface PlanStreamEvent {
  * reusing that type is how the two stay in step. `orchestration_step` frames carry the live
  * status of a step as it runs; content deltas arrive exactly as they do in chat.
  */
-export interface RunStreamEvent extends ChatStreamEvent {
+export interface RunStreamEvent extends ChatStreamEvent, OrchestrationAttempt {
     step_id?: string;
     status?: StepStatus;
     summary?: string;
+    reused?: boolean;
+    reused_from_run_id?: string | null;
+    checkpoint_available?: boolean;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -542,6 +655,9 @@ export interface RunStreamResult {
     /** The plan was already run elsewhere. Distinct from `errored`; see `onAlreadyRun`. */
     alreadyRun: boolean;
     conflict?: OrchestrationRequestError;
+    rejection?: OrchestrationRequestError;
+    /** No terminal acknowledgement: the server may still be executing. */
+    transportUnknown?: boolean;
 }
 
 export const ORCHESTRATION_PLAN_PATH = '/api/v2/orchestration/plan';
@@ -560,7 +676,7 @@ export const ORCHESTRATION_RUNS_PATH = '/api/v2/orchestration/runs';
  * plans -- so anything that needs the steps themselves fetches the run through
  * `fetchOrchestrationRun`.
  */
-export interface PersistedRunSummary {
+export interface PersistedRunSummary extends OrchestrationAttempt {
     run_id: string;
     conversation_id: string;
     /** The turn this run answered. Present on every run the plan route created. */
@@ -608,6 +724,10 @@ export interface PersistedRunStep {
     title?: string;
     status?: StepStatus;
     summary?: string;
+    failure?: OrchestrationFailure | null;
+    reused?: boolean;
+    reused_from_run_id?: string | null;
+    checkpoint_available?: boolean;
     [key: string]: unknown;
 }
 
@@ -665,6 +785,27 @@ export async function fetchRunSteps(
         options.signal,
     );
     return Array.isArray(payload?.steps) ? payload.steps : [];
+}
+
+export async function prepareOrchestrationRetry(
+    runId: string,
+    body: {
+        conversation_id: string;
+        submission_id: string;
+        expected_version: string;
+        confirm_external_effects: boolean;
+    },
+): Promise<PersistedRun> {
+    const payload = await api.post<{ run: PersistedRun }>(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}/retry`, body,
+    );
+    return payload.run;
+}
+
+export async function cancelOrchestrationRun(runId: string, conversationId: string): Promise<void> {
+    await api.post(`/api/v2/orchestration/cancel/${encodeURIComponent(runId)}`, {
+        conversation_id: conversationId,
+    });
 }
 
 export async function beginPlanEdit(
@@ -935,8 +1076,8 @@ async function readPlanStream(
  * resolve on the terminal frame.
  *
  * The terminal frame is shaped like chat's `done` payload, so `onDone` receives the same
- * assistant-message metadata a chat completion would carry. As with the plan stream, an abort
- * resolves with `cancelled: true` rather than throwing.
+ * assistant-message metadata a chat completion would carry. Reader aborts and unexpected EOF
+ * report unknown transport state; only a server terminal frame can establish cancellation.
  */
 export async function runOrchestration(
     body: OrchestrationRunRequest,
@@ -968,27 +1109,33 @@ export async function runOrchestration(
                 return;
             }
             // Uncoded/legacy 409s and already_run retain the existing duplicate-run recovery.
-            if (error?.status === 409) {
+            if (error?.status === 409 && (!error.code || error.code === 'already_run')) {
                 result.alreadyRun = true;
                 handlers.onAlreadyRun?.(message);
                 return;
             }
-            result.errored = true;
-            handlers.onError?.(message);
+            if (error?.status === 409 || error?.status === 400 || error?.status === 401
+                || error?.status === 403 || error?.status === 404) {
+                result.rejection = error;
+                result.errored = true;
+                return;
+            }
+            result.transportUnknown = true;
         },
     );
     if (!response) {
         if (signal?.aborted) {
-            result.cancelled = true;
+            result.transportUnknown = true;
         }
         return result;
     }
 
     const onEvent = (event: RunStreamEvent): boolean => {
-        if (typeof event.error === 'string' && event.error) {
+        if (typeof event.error === 'string' && event.error && !event.done) {
             result.errored = true;
             handlers.onError?.(event.error, event);
-            return true;
+            // Finalization can still provide a safe terminal status after a save error.
+            return false;
         }
 
         // A run streams progress on the same `thought` event planning uses, and those frames
@@ -1012,17 +1159,17 @@ export async function runOrchestration(
         }
 
         if (event.done) {
-            const wasCancelled =
-                Boolean(event.cancelled) ||
-                Boolean(event.canceled) ||
-                event.type === 'cancelled' ||
-                event.type === 'canceled';
+            if (typeof event.full_content === 'string') {
+                result.accumulated = event.full_content;
+            }
+            const wasCancelled = orchestrationTerminalStatus(event) === 'cancelled';
 
             if (wasCancelled) {
                 result.cancelled = true;
                 handlers.onCancelled?.(event, result.accumulated);
             } else {
-                result.completed = true;
+                result.completed = orchestrationTerminalStatus(event) === 'completed';
+                result.errored = orchestrationTerminalStatus(event) === 'failed';
                 handlers.onDone?.(event, result.accumulated);
             }
             return true;
@@ -1034,18 +1181,16 @@ export async function runOrchestration(
     const outcome = await readSsePost<RunStreamEvent>(response, onEvent, signal);
 
     if (outcome.aborted) {
-        result.cancelled = true;
+        result.transportUnknown = true;
     } else if (outcome.transportError) {
-        result.errored = true;
-        handlers.onError?.(outcome.transportError.message);
+        result.transportUnknown = true;
     } else if (
         outcome.endedWithoutTerminal &&
         !result.completed &&
         !result.cancelled &&
         !result.errored
     ) {
-        result.errored = true;
-        handlers.onError?.('The run ended unexpectedly.');
+        result.transportUnknown = true;
     }
 
     return result;

--- a/application/v2_ui/src/lib/orchestrationController.ts
+++ b/application/v2_ui/src/lib/orchestrationController.ts
@@ -18,7 +18,14 @@ import { createConversation } from './endpoints';
 import { ApiError } from './apiClient';
 import {
     beginPlanEdit,
+    cancelOrchestrationRun,
     fetchOrchestrationRun,
+    fetchRunSteps,
+    isOrchestrationRunPending,
+    normalizeOrchestrationAttempt,
+    normalizeOrchestrationRecovery,
+    orchestrationTerminalStatus,
+    prepareOrchestrationRetry,
     fetchPlanEditor,
     MAX_PLAN_INSTRUCTION_LENGTH,
     orchestrationErrorInfo,
@@ -37,6 +44,8 @@ import {
     type PlanRevisionAction,
     type PlanRevisionRequest,
     type RunStreamEvent,
+    type PersistedRun,
+    type PlanEdits,
 } from './orchestration';
 import { applyPlanEdits, isPlanApproved, isPlanAwaitingApproval, isPlanRunnable, normalizePlan } from './orchestrationPlan';
 import type { Json } from './types';
@@ -104,6 +113,7 @@ const turnContexts = new Map<string, TurnContext>();
  * re-plan superseding a plan — reaches the right one while another conversation's run is untouched.
  */
 const activeControllers = new Map<string, AbortController>();
+const activeRunIds = new Map<string, string>();
 /** Editor requests never abort, begin, settle, or append a main-thread turn. */
 const editorControllers = new Map<string, AbortController>();
 
@@ -230,6 +240,7 @@ async function dispatchPlan(
     // A re-plan supersedes whatever was open for this conversation.
     activeControllers.get(currentConversationId)?.abort();
     activeControllers.set(currentConversationId, controller);
+    activeRunIds.delete(currentConversationId);
 
     /**
      * Adopt the conversation id the server just announced, if it is not the one we already hold.
@@ -591,8 +602,8 @@ export async function answerElicitation(params: {
  * The run request carries the narrowing edits so the server applies them before executing; the
  * browser never assembles the plan that runs. `beginRun` guards a double approval — a second press
  * or a restored record — by refusing a run id already tracked. Every terminal path settles the
- * thread and ends the run; a bare abort (Stop, with no terminal frame) is settled after the await,
- * because `runOrchestration` reports that as `cancelled` without calling a handler.
+ * thread and ends the run. A dropped reader is reconciled against the saved attempt instead of
+ * guessing that execution ended or that the user cancelled it.
  */
 export async function approveAndRunPlan(params: {
     conversationId: string;
@@ -610,6 +621,16 @@ export async function approveAndRunPlan(params: {
     if (!isPlanRunnable(applyPlanEdits(plan, edits))) {
         return;
     }
+    await executeSavedPlan(conversationId, turnId, plan, edits);
+}
+
+async function executeSavedPlan(
+    conversationId: string,
+    turnId: string,
+    plan: OrchestrationPlan,
+    edits?: PlanEdits,
+): Promise<void> {
+    const store = useOrchestrationStore.getState();
 
     const runId = plan.run_id;
     const planId = plan.plan_id;
@@ -635,12 +656,14 @@ export async function approveAndRunPlan(params: {
     const controller = new AbortController();
     activeControllers.get(conversationId)?.abort();
     activeControllers.set(conversationId, controller);
+    activeRunIds.set(conversationId, runId);
 
     const runBody: OrchestrationRunRequest = {
         run_id: runId,
         plan_id: planId,
         conversation_id: conversationId,
-        edits,
+        ...(edits ? { edits } : {}),
+        // A retry uses its returned child plan version, not the source recovery token.
         ...(plan.edit_version ? { expected_version: plan.edit_version } : {}),
     };
 
@@ -669,31 +692,41 @@ export async function approveAndRunPlan(params: {
                 useChatStore.getState().pushOrchestrationContent(conversationId, accumulated),
             onDone: (event, accumulated) => {
                 settled = true;
+                const status = orchestrationTerminalStatus(event);
+                const terminal = { ...event, run_id: runId, turn_id: turnId };
+                useOrchestrationStore.getState().updateRunRecovery(runId, {
+                    ...normalizeOrchestrationAttempt(terminal), status, plan,
+                    transportUnknown: false, checking: false,
+                    error: event.message_saved === false
+                        ? 'This explanation could not be saved to the conversation. It is kept in this tab; review saved progress before leaving.' : null,
+                });
                 useOrchestrationStore.getState().mergeReasoningAdjustments(
                     conversationId, turnId, event.reasoning_adjustments ?? event.metadata?.reasoning_adjustments,
                 );
                 useChatStore.getState().settleOrchestrationTurn(conversationId, {
-                    status: 'completed',
-                    event,
+                    status,
+                    event: terminal,
                     accumulated,
                     pendingUserMessageId: context?.pendingUserMessageId ?? null,
                 });
-                useOrchestrationStore.getState().endRun(runId, 'completed');
+                useOrchestrationStore.getState().endRun(runId, status);
             },
-            onCancelled: (_event, accumulated) => {
+            onCancelled: (event, accumulated) => {
                 settled = true;
+                const terminal = { ...event, run_id: runId, turn_id: turnId, status: 'cancelled' as const };
+                useOrchestrationStore.getState().updateRunRecovery(runId, {
+                    ...normalizeOrchestrationAttempt(terminal), status: 'cancelled', plan,
+                    transportUnknown: false, checking: false,
+                    error: event.message_saved === false
+                        ? 'This explanation could not be saved to the conversation. It is kept in this tab; review saved progress before leaving.' : null,
+                });
                 useChatStore
                     .getState()
-                    .settleOrchestrationTurn(conversationId, { status: 'cancelled', accumulated });
+                    .settleOrchestrationTurn(conversationId, { status: 'cancelled', event: terminal, accumulated });
                 useOrchestrationStore.getState().endRun(runId, 'cancelled');
             },
-            onError: (message) => {
-                settled = true;
-                useChatStore
-                    .getState()
-                    .settleOrchestrationTurn(conversationId, { status: 'failed', error: message });
-                useOrchestrationStore.getState().endRun(runId, 'failed');
-            },
+            // Older error-only frames do not prove that finalization reached storage.
+            onError: () => {},
             onConflict: (message) => {
                 settled = true;
                 conflictMessage = message;
@@ -712,14 +745,7 @@ export async function approveAndRunPlan(params: {
             // quietly and the conversation re-read -- the answer the other device produced is
             // already stored, and fetching it is how this device catches up.
             onAlreadyRun: () => {
-                settled = true;
-                useChatStore.getState().settleOrchestrationTurn(conversationId, {
-                    status: 'cancelled',
-                    accumulated: '',
-                });
-                useOrchestrationStore.getState().endRun(runId, 'completed');
-                useOrchestrationStore.getState().clearActiveTurn(conversationId);
-                void useChatStore.getState().reloadMessages();
+                // Read the existing attempt; it might still be running, failed, or stopped.
             },
         },
         controller.signal,
@@ -727,38 +753,302 @@ export async function approveAndRunPlan(params: {
 
     if (activeControllers.get(conversationId) === controller) {
         activeControllers.delete(conversationId);
+        activeRunIds.delete(conversationId);
     }
     if (result.conflict) {
         await refreshOrchestrationPlanEditor(
             { conversationId, turnId }, result.conflict.current_run_id ?? runId, conflictMessage,
         );
     }
+    if (result.rejection) {
+        const current = useOrchestrationStore.getState();
+        current.releaseRunAttempt(runId);
+        current.updateRunRecovery(runId, {
+            run_id: runId, turn_id: turnId, plan, status: plan.status,
+            transportUnknown: false,
+            error: 'The saved attempt was not started. Its saved progress or access may have changed. Review the current attempt; no steps were replayed.',
+        });
+        useChatStore.getState().settleOrchestrationTurn(conversationId, { status: 'planned' });
+        return;
+    }
 
     if (!settled) {
-        // A bare abort: Stop was pressed and the stream dropped before any terminal frame. Keep
-        // whatever partial answer had arrived, matching a cancelled chat stream.
-        useChatStore.getState().settleOrchestrationTurn(conversationId, {
-            status: 'cancelled',
-            accumulated: result.accumulated,
+        useOrchestrationStore.getState().updateRunRecovery(runId, {
+            run_id: runId, turn_id: turnId, plan, transportUnknown: true,
         });
-        useOrchestrationStore.getState().endRun(runId, 'cancelled');
+        if (!activeControllers.has(conversationId)) {
+            useChatStore.getState().settleOrchestrationTurn(conversationId, {
+                status: 'unknown',
+                event: { run_id: runId, turn_id: turnId },
+                accumulated: result.accumulated,
+            });
+        }
+        await reconcileOrchestrationRun(conversationId, runId);
     }
 }
 
-/**
- * Stop the in-flight plan or run for a conversation.
- *
- * Aborting the reader is all that is available: orchestration has no run-cancel endpoint the way
- * chat does, so the server may finish the work unwatched. The UI settles either way, and the
- * partial answer is kept.
- */
-export function cancelOrchestration(conversationId: string): void {
-    activeControllers.get(conversationId)?.abort();
+const reconciliationTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const recoverySubmissions = new Map<string, { id: string; version: string; confirmed: boolean; unresolved: boolean }>();
+const recoveryLocks = new Set<string>();
+
+export async function loadOrchestrationRecovery(conversationId: string, runId: string): Promise<PersistedRun | null> {
+    const record = await fetchOrchestrationRun(runId, { conversationId });
+    if (!record || record.run_id !== runId || record.conversation_id !== conversationId) {
+        throw new Error('Recovery record unavailable');
+    }
+    const plan = normalizePlan(record.plan);
+    useOrchestrationStore.getState().updateRunRecovery(runId, {
+        ...normalizeOrchestrationAttempt(record),
+        status: record.status,
+        ...(plan ? { plan } : {}),
+        detailLoaded: true,
+    });
+    return record;
+}
+
+/** Read-only polling never approves, retries, or invents a cancellation reason. */
+export async function reconcileOrchestrationRun(conversationId: string, runId: string): Promise<void> {
+    const timer = reconciliationTimers.get(runId);
+    if (timer) clearTimeout(timer);
+    reconciliationTimers.delete(runId);
+    const store = useOrchestrationStore.getState();
+    if (store.runRecovery[runId]?.checking) return;
+    store.updateRunRecovery(runId, { checking: true, transportUnknown: true });
+    try {
+        const record = await loadOrchestrationRecovery(conversationId, runId);
+        if (!record) return;
+        const steps = await fetchRunSteps(runId, { conversationId }).catch(() => []);
+        const current = useOrchestrationStore.getState();
+        if (record.turn_id && selectPlan(current, conversationId, record.turn_id)?.run_id === runId) {
+            current.adoptPersistedPlan(conversationId, record.turn_id, record.plan, steps);
+        }
+        const terminal = record.status === 'completed' || record.status === 'failed' || record.status === 'cancelled';
+        if (terminal && !isOrchestrationRunPending(record)) {
+            const event: RunStreamEvent = {
+                ...normalizeOrchestrationAttempt(record),
+                status: record.status === 'cancelled' ? 'cancelled' : record.status === 'failed' ? 'failed' : 'completed',
+                message_id: record.assistant_message_id ?? undefined,
+            };
+            const status = orchestrationTerminalStatus(event);
+            current.updateRunRecovery(runId, { transportUnknown: false, checking: false, error: null });
+            current.endRun(runId, status);
+            const chat = useChatStore.getState();
+            const otherRun = Object.values(current.inFlight)
+                .some((run) => run.conversationId === conversationId && run.runId !== runId);
+            const activeTurn = current.activeTurns[conversationId];
+            if (chat.activeConversationId === conversationId && !otherRun
+                && (!chat.streaming || !activeTurn || activeTurn === record.turn_id)) {
+                const partial = chat.messages.find((message) => message.id === `orchestration-status-${runId}`)?.content ?? '';
+                chat.settleOrchestrationTurn(conversationId, {
+                    status, event, accumulated: record.assistant_message_id ? '' : partial,
+                });
+                // Saved messages own final content, citations and artifact metadata.
+                if (record.assistant_message_id) await useChatStore.getState().reloadMessages();
+                else current.updateRunRecovery(runId, {
+                    error: record.finalization_status === 'interrupted'
+                        ? 'Execution was interrupted before a final conversation message could be confirmed. Review the saved status and recovery options.'
+                        : record.message_saved === false || record.finalization_status === 'failed'
+                        ? 'The run ended, but its conversation message was not saved. This visible status is kept in this tab.'
+                        : 'This run ended without a linked conversation message. Review its saved status and recovery options.',
+                });
+            }
+            return;
+        }
+        current.updateRunRecovery(runId, {
+            checking: false,
+            error: terminal
+                ? 'The server is saving the final response. Checking saved status; no retry will start.'
+                : 'The server has not confirmed a final result. Execution may still be running. Checking saved status; no retry will start.',
+        });
+    } catch {
+        useOrchestrationStore.getState().updateRunRecovery(runId, {
+            checking: false,
+            error: 'The saved run status could not be reached. Execution may still be running. No retry will start until its status is confirmed.',
+        });
+    }
+    reconciliationTimers.set(runId, setTimeout(() => {
+        void reconcileOrchestrationRun(conversationId, runId);
+    }, 5000));
+}
+
+export function openOrchestrationRecovery(conversationId: string, runId: string): void {
+    useOrchestrationStore.setState({ recoveryTarget: { conversationId, runId } });
+    useChatStore.getState().setDrawerMode('plan');
+    void loadOrchestrationRecovery(conversationId, runId).then((record) => {
+        if (record && isOrchestrationRunPending(record)) {
+            return reconcileOrchestrationRun(conversationId, runId);
+        }
+    }).catch(() => {
+        useOrchestrationStore.getState().updateRunRecovery(runId, {
+            error: 'The saved attempt could not be loaded. Your previous failure and progress have been kept.',
+        });
+    });
+}
+
+export async function retryOrchestrationRun(
+    conversationId: string,
+    runId: string,
+    confirmedVersion?: string,
+): Promise<{ confirmationRequired?: boolean; version?: string }> {
+    const key = scopeKey(conversationId, runId);
+    const store = useOrchestrationStore.getState();
+    if (recoveryLocks.has(key)) return {};
+    const fail = (error: string) => useOrchestrationStore.getState().updateRunRecovery(runId, { error });
+    if (useChatStore.getState().activeConversationId !== conversationId
+        || useChatStore.getState().streaming
+        || Object.values(store.inFlight).some((run) => run.conversationId === conversationId)) {
+        fail('Finish or stop the current request, then review this saved attempt before retrying.');
+        return {};
+    }
+    recoveryLocks.add(key);
+    store.updateRunRecovery(runId, { busy: true, error: null });
+    const initialTurn = store.activeTurns[conversationId];
+    try {
+        const record = await loadOrchestrationRecovery(conversationId, runId);
+        const recovery = normalizeOrchestrationRecovery(record?.recovery);
+        const previous = recoverySubmissions.get(key);
+        if (!record || !recovery || (!previous?.unresolved && (!recovery.eligible || !recovery.expected_version
+            || recovery.source_run_id !== runId
+            || (recovery.current_run_id && recovery.current_run_id !== runId)))) {
+            fail(recovery?.message || 'This saved attempt cannot be resumed. Review the current attempt or start a new plan deliberately.');
+            return {};
+        }
+        if (!previous?.unresolved && confirmedVersion && confirmedVersion !== recovery.expected_version) {
+            fail('The recovery preview changed. Review the updated saved steps before confirming another retry.');
+            return {};
+        }
+        if (!previous?.unresolved && recovery.requires_confirmation && confirmedVersion !== recovery.expected_version) {
+            return { confirmationRequired: true, version: recovery.expected_version ?? undefined };
+        }
+        const confirmed = recovery.requires_confirmation && confirmedVersion === recovery.expected_version;
+        const submission = previous?.unresolved ? previous
+            : { id: makeTurnId(), version: recovery.expected_version ?? '', confirmed, unresolved: true };
+        recoverySubmissions.set(key, submission);
+        const child = await prepareOrchestrationRetry(runId, {
+            conversation_id: conversationId,
+            submission_id: submission.id,
+            expected_version: submission.version,
+            confirm_external_effects: submission.confirmed,
+        });
+        submission.unresolved = false;
+        const plan = normalizePlan(child.plan);
+        if (!plan || child.conversation_id !== conversationId || child.turn_id !== record.turn_id
+            || child.retry_of_run_id !== runId || child.run_id !== plan.run_id
+            || plan.conversation_id !== conversationId || plan.turn_id !== record.turn_id) {
+            fail('The prepared attempt could not be verified. Nothing was executed. Reload the saved run before continuing.');
+            return {};
+        }
+        const current = useOrchestrationStore.getState();
+        current.updateRunRecovery(runId, {
+            latest_attempt_run_id: child.run_id,
+            recovery: { ...recovery, eligible: false, current_run_id: child.run_id },
+        });
+        current.updateRunRecovery(child.run_id, { ...normalizeOrchestrationAttempt(child), plan, status: child.status });
+        if (useChatStore.getState().activeConversationId !== conversationId
+            || useChatStore.getState().streaming
+            || current.activeTurns[conversationId] !== initialTurn
+            || Object.values(current.inFlight).some((run) => run.conversationId === conversationId)) {
+            fail('A retry was prepared but not started because the active request changed. Open the current saved attempt to continue manually.');
+            return {};
+        }
+        // Never replan or append a user message. The saved child is the server's effective plan.
+        current.setPlan(conversationId, plan.turn_id, plan);
+        current.setActiveTurn(conversationId, plan.turn_id);
+        current.pinRun(null);
+        useOrchestrationStore.setState({ recoveryTarget: null });
+        await executeSavedPlan(conversationId, plan.turn_id, plan);
+        return {};
+    } catch (error) {
+        const info = error instanceof ApiError ? orchestrationErrorInfo(error.payload, error.status) : {};
+        if (info.code) recoverySubmissions.delete(key);
+        const payload = error instanceof ApiError && error.payload && typeof error.payload === 'object'
+            ? error.payload as Record<string, unknown> : {};
+        const recovery = normalizeOrchestrationRecovery(payload.recovery);
+        if (recovery) useOrchestrationStore.getState().updateRunRecovery(runId, { recovery });
+        if (info.code === 'confirmation_required' && recovery?.expected_version) {
+            return { confirmationRequired: true, version: recovery.expected_version };
+        }
+
+        if (info.current_run_id) useOrchestrationStore.getState().updateRunRecovery(runId, {
+            latest_attempt_run_id: info.current_run_id,
+        });
+        fail(info.code === 'recovery_changed'
+            ? 'Recovery changed or a newer attempt already exists. Review the current attempt; no work was started by this request.'
+            : 'Recovery could not be prepared. Your previous failure and saved progress have been kept. Check the saved status and try again.');
+        return {};
+    } finally {
+        recoveryLocks.delete(key);
+        useOrchestrationStore.getState().updateRunRecovery(runId, { busy: false });
+    }
+}
+
+export async function runPreparedOrchestrationRetry(conversationId: string, runId: string): Promise<void> {
+    const key = scopeKey(conversationId, runId);
+    if (recoveryLocks.has(key)) return;
+    recoveryLocks.add(key);
+    const fail = () => useOrchestrationStore.getState().updateRunRecovery(runId, {
+        error: 'This saved retry cannot start right now. Check the current attempt and finish any active request first.',
+    });
+    try {
+        const record = await loadOrchestrationRecovery(conversationId, runId);
+        const plan = normalizePlan(record?.plan);
+        if (!plan || !record?.retry_of_run_id || (record.status !== 'awaiting_approval' && record.status !== 'approved')
+            || plan.run_id !== runId || plan.conversation_id !== conversationId || plan.turn_id !== record.turn_id
+            || useChatStore.getState().activeConversationId !== conversationId || useChatStore.getState().streaming
+            || Object.values(useOrchestrationStore.getState().inFlight).some((run) => run.conversationId === conversationId)) {
+            fail();
+            return;
+        }
+        const source = await loadOrchestrationRecovery(conversationId, record.retry_of_run_id);
+        const latest = source?.latest_attempt_run_id || source?.recovery?.current_run_id;
+        if (latest !== runId || useChatStore.getState().activeConversationId !== conversationId
+            || useChatStore.getState().streaming) {
+            fail();
+            return;
+        }
+        const current = useOrchestrationStore.getState();
+        current.setPlan(conversationId, plan.turn_id, plan);
+        current.setActiveTurn(conversationId, plan.turn_id);
+        useOrchestrationStore.setState({ recoveryTarget: null });
+        await executeSavedPlan(conversationId, plan.turn_id, plan);
+    } catch {
+        fail();
+    } finally {
+        recoveryLocks.delete(key);
+    }
+}
+
+export async function cancelOrchestration(conversationId: string, runId?: string): Promise<void> {
+    if (!runId && activeControllers.has(conversationId) && !activeRunIds.has(conversationId)) {
+        activeControllers.get(conversationId)?.abort();
+        return;
+    }
+    const runs = Object.values(useOrchestrationStore.getState().inFlight)
+        .filter((candidate) => candidate.conversationId === conversationId);
+    const targetId = runId ?? activeRunIds.get(conversationId);
+    const run = targetId ? runs.find((candidate) => candidate.runId === targetId)
+        : runs.sort((left, right) => right.startedAt - left.startedAt)[0];
+    if (!run) {
+        if (!runId) activeControllers.get(conversationId)?.abort();
+        return;
+    }
+    const controller = activeRunIds.get(conversationId) === run.runId
+        ? activeControllers.get(conversationId) : undefined;
+    try {
+        await cancelOrchestrationRun(run.runId, conversationId);
+        if (activeControllers.get(conversationId) === controller) controller?.abort();
+        await reconcileOrchestrationRun(conversationId, run.runId);
+    } catch {
+        useOrchestrationStore.getState().updateRunRecovery(run.runId, {
+            error: 'Stop could not be confirmed by the server. Execution may still be running. Try Stop again or check saved status.',
+        });
+    }
 }
 
 /** Whether a plan or run is streaming for a conversation, so Stop can route to the right cancel. */
 export function hasActiveOrchestration(conversationId: string): boolean {
-    return activeControllers.has(conversationId);
+    return activeControllers.has(conversationId)
+        || Object.values(useOrchestrationStore.getState().inFlight).some((run) => run.conversationId === conversationId);
 }
 
 /**

--- a/application/v2_ui/src/lib/orchestrationResume.ts
+++ b/application/v2_ui/src/lib/orchestrationResume.ts
@@ -25,8 +25,8 @@ import {
     selectPlan,
     useOrchestrationStore,
 } from '../stores/orchestrationStore';
-import { fetchConversationRuns, fetchOrchestrationRun, fetchRunSteps } from './orchestration';
-import { refreshOrchestrationPlanEditor } from './orchestrationController';
+import { fetchConversationRuns, fetchOrchestrationRun, fetchRunSteps, isOrchestrationRunPending } from './orchestration';
+import { loadOrchestrationRecovery, reconcileOrchestrationRun, refreshOrchestrationPlanEditor } from './orchestrationController';
 import type { Json } from './orchestration';
 
 /** How many runs to ask for. Matches the store's per-conversation history cap. */
@@ -82,6 +82,29 @@ export async function resumeOrchestrationForConversation(
         return;
     }
 
+    const newest = useOrchestrationStore.getState().hydratedHistory[conversationId]?.[0];
+    const pending = newest && isOrchestrationRunPending({ ...newest.attempt, status: newest.planStatus });
+    if (newest && (newest.planStatus === 'failed' || newest.planStatus === 'cancelled' || pending)) {
+        try {
+            const record = await loadOrchestrationRecovery(conversationId, newest.runId);
+            const steps = await fetchRunSteps(newest.runId, { conversationId });
+            const current = useOrchestrationStore.getState();
+            if (record && !selectActiveTurn(current, conversationId)
+                && useChatStore.getState().activeConversationId === conversationId) {
+                current.adoptPersistedPlan(conversationId, newest.turnId, record.plan, steps);
+                current.setActiveTurn(conversationId, newest.turnId);
+            }
+            if (record && (pending || isOrchestrationRunPending(record))) {
+                current.beginRun({
+                    conversationId, turnId: newest.turnId, runId: newest.runId,
+                    planId: newest.planId, startedAt: Date.now(),
+                });
+                void reconcileOrchestrationRun(conversationId, newest.runId);
+            }
+        } catch {
+            consideredConversations.delete(conversationId);
+        }
+    }
     await restorePendingApproval(conversationId);
 }
 
@@ -196,7 +219,7 @@ function neutralizeTimedApproval(plan: Json): Json {
         return plan;
     }
     const approvalRecord = approval as Record<string, unknown>;
-    if (approvalRecord.mode !== 'timed') {
+    if (approvalRecord.mode !== 'timed' && approvalRecord.mode !== 'auto') {
         return plan;
     }
     return {

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -103,6 +103,8 @@ import { messageThreadId } from '../lib/threads';
 import { proposalSourceMessageId, type ImageProposalSpec } from '../lib/imageProposalSpec';
 import { toast } from './toastStore';
 import { ApiError } from '../lib/apiClient';
+import { normalizeOrchestrationAttempt } from '../lib/orchestration';
+import { openOrchestrationRecovery } from '../lib/orchestrationController';
 import { foundryAuthUrl } from '../lib/foundryAuth';
 import { useBootstrapStore } from './bootstrapStore';
 import { useCollaborationStore, participantName } from './collaborationStore';
@@ -142,7 +144,7 @@ export type DrawerMode = 'contents' | 'documents' | 'plan' | null;
  */
 export type OrchestrationTurnOutcome =
     | {
-          status: 'completed';
+          status: 'completed' | 'failed' | 'cancelled' | 'unknown';
           event: RunStreamEvent;
           accumulated: string;
           /** The optimistic user bubble to reconcile with the server's id, when one is known. */
@@ -2599,7 +2601,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return;
         }
 
-        if (outcome.status === 'failed') {
+        if (outcome.status === 'failed' && !('event' in outcome)) {
             set({
                 streaming: false,
                 streamingContent: '',
@@ -2610,7 +2612,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return;
         }
 
-        if (outcome.status === 'cancelled') {
+        if (outcome.status === 'cancelled' && !('event' in outcome)) {
             // Partial output is kept, matching a cancelled chat stream: discarding a long answer
             // someone stopped is more annoying than useful.
             const { accumulated } = outcome;
@@ -2641,12 +2643,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // conversation echoes the same message over its event stream and the second copy must
         // update the first rather than double it.
         const { event, accumulated, pendingUserMessageId } = outcome;
+        const attempt = normalizeOrchestrationAttempt(event);
+        const fallback = outcome.status === 'unknown'
+            ? 'The connection to this run ended before a final result was confirmed. Checking its saved status; execution may still be running.'
+            : attempt.failure?.message || (outcome.status === 'cancelled'
+                ? 'This run was stopped. Any available partial results have been kept.'
+                : 'This run could not complete. Review the saved attempt for recovery options.');
         const persistedUserId = String(event.user_message_id ?? '').trim();
         const finalMessage: ChatMessage = {
-            id: String(event.message_id ?? STREAMING_MESSAGE_ID),
+            id: String(event.message_id ?? (attempt.run_id ? `orchestration-status-${attempt.run_id}` : STREAMING_MESSAGE_ID)),
             conversation_id: conversationId,
             role: 'assistant',
-            content: accumulated,
+            content: typeof event.full_content === 'string' && event.full_content
+                ? event.full_content : accumulated || (outcome.status === 'completed' ? '' : fallback),
             timestamp: new Date().toISOString(),
             model_deployment_name: event.model_deployment_name,
             agent_display_name: event.agent_display_name,
@@ -2658,7 +2667,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
             web_search_citations:
                 event.web_search_citations as ChatMessage['web_search_citations'],
             agent_citations: event.agent_citations as ChatMessage['agent_citations'],
-            metadata: reasoningMetadataForEvent(event),
+            metadata: {
+                ...event.metadata,
+                ...reasoningMetadataForEvent(event),
+                orchestration: {
+                    ...(event.metadata?.orchestration && typeof event.metadata.orchestration === 'object'
+                        ? event.metadata.orchestration : {}),
+                    ...attempt,
+                },
+            },
             thoughts: get().thoughts.length > 0 ? [...get().thoughts] : undefined,
         };
         set((state) => {
@@ -2666,14 +2683,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // per-message actions address a message the server knows. Matched on the exact pending
             // id rather than any `pending-user-` bubble, so an earlier cancelled turn's unresolved
             // bubble is left alone.
+            const existing = attempt.run_id && event.message_id
+                ? state.messages.filter((message) => message.id !== `orchestration-status-${attempt.run_id}`)
+                : state.messages;
             const messages =
                 persistedUserId && pendingUserMessageId
-                    ? state.messages.map((message) =>
+                    ? existing.map((message) =>
                           message.id === pendingUserMessageId
                               ? { ...message, id: persistedUserId }
                               : message,
                       )
-                    : state.messages;
+                    : existing;
             return {
                 messages: mergeCollaborationMessage(
                     messages,
@@ -2682,6 +2702,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 streaming: false,
                 streamingContent: '',
                 reconnectPhase: null,
+                streamError: null,
+                streamAuthUrl: null,
             };
         });
 
@@ -2847,6 +2869,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     retryMessage: async (messageId, options) => {
         if (get().streaming) {
+            return;
+        }
+        const message = get().messages.find((candidate) => candidate.id === messageId);
+        const attempt = normalizeOrchestrationAttempt(message?.metadata?.orchestration);
+        const recoveryConversationId = get().activeConversationId;
+        if (attempt.run_id && recoveryConversationId) {
+            openOrchestrationRecovery(recoveryConversationId, attempt.run_id);
+            return;
+        }
+        if (message?.metadata?.orchestration) {
+            set({
+                streamError: 'This historical orchestration message has no saved attempt identity. It cannot be resumed; create a new plan deliberately if needed.',
+                streamAuthUrl: null,
+            });
             return;
         }
         set({

--- a/application/v2_ui/src/stores/orchestrationStore.ts
+++ b/application/v2_ui/src/stores/orchestrationStore.ts
@@ -23,6 +23,7 @@
 
 import { create } from 'zustand';
 import { normalizeReasoningAdjustments } from '../lib/reasoning';
+import { isOrchestrationRunPending, normalizeOrchestrationAttempt, normalizeOrchestrationFailure } from '../lib/orchestration';
 import { createElicitationDraft, type ElicitationDraft } from '../lib/elicitationAnswers';
 import {
     applyPlanEdits,
@@ -36,6 +37,8 @@ import {
 import type {
     Elicitation,
     OrchestrationPlan,
+    OrchestrationAttempt,
+    OrchestrationFailure,
     OrchestrationStep,
     PersistedRunStep,
     PersistedRunSummary,
@@ -79,6 +82,18 @@ function coerceStepStatus(value: unknown): StepStatus | null {
 export interface StepRuntime {
     status: StepStatus;
     summary: string;
+    reused?: boolean;
+    failure?: OrchestrationFailure | null;
+}
+
+export interface RunRecoveryState extends OrchestrationAttempt {
+    status?: PlanStatus | null;
+    plan?: OrchestrationPlan;
+    busy?: boolean;
+    error?: string | null;
+    transportUnknown?: boolean;
+    checking?: boolean;
+    detailLoaded?: boolean;
 }
 
 export type StepRuntimeMap = Record<string, StepRuntime>;
@@ -142,6 +157,7 @@ export interface RunHistoryEntry {
     planStatus?: PlanStatus | null;
     stepCount?: number;
     artifactCount?: number;
+    attempt?: OrchestrationAttempt;
 }
 
 /** History is bounded per conversation; a long session should not grow one without limit. */
@@ -198,7 +214,9 @@ export function historyEntryFromPersistedRun(run: PersistedRunSummary): RunHisto
 
     const planStatus = (run.status ?? run.plan_summary?.status ?? null) as PlanStatus | null;
     let status: RunDisplayStatus;
-    if (planStatus === 'completed') {
+    if (run.outcome === 'partial' || run.outcome === 'failed') {
+        status = 'failed';
+    } else if (planStatus === 'completed') {
         status = 'completed';
     } else if (planStatus === 'failed') {
         status = 'failed';
@@ -222,6 +240,7 @@ export function historyEntryFromPersistedRun(run: PersistedRunSummary): RunHisto
         planStatus,
         stepCount: run.plan_summary?.step_count ?? 0,
         artifactCount: run.artifact_count ?? 0,
+        attempt: normalizeOrchestrationAttempt(run),
     };
 }
 
@@ -273,6 +292,9 @@ function newPlanEditorSession(): PlanEditorSession {
 }
 
 interface OrchestrationState {
+    recoveryTarget: { conversationId: string; runId: string } | null;
+    runRecovery: Record<string, RunRecoveryState>;
+    updateRunRecovery: (runId: string, patch: RunRecoveryState) => void;
     /** The current plan per turn, keyed by `scopeKey`. */
     plans: Record<string, OrchestrationPlan>;
     /** A pending question per turn, when the planner asked instead of planning. */
@@ -464,6 +486,11 @@ interface OrchestrationState {
 /* -------------------------------------------------------------------------- */
 
 export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
+    recoveryTarget: null,
+    runRecovery: {},
+    updateRunRecovery: (runId, patch) => set((state) => ({
+        runRecovery: { ...state.runRecovery, [runId]: { ...state.runRecovery[runId], ...patch } },
+    })),
     plans: {},
     elicitations: {},
     elicitationDrafts: {},
@@ -804,10 +831,13 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             const current = state.stepRuntime[key] ?? EMPTY_STEP_RUNTIME;
             const existing = current[stepId] ?? { status: 'pending', summary: '' };
             const merged: StepRuntime = {
+                ...existing,
+                ...patch,
                 status: patch.status ?? existing.status,
                 summary: patch.summary ?? existing.summary,
             };
-            if (merged.status === existing.status && merged.summary === existing.summary) {
+            if (merged.status === existing.status && merged.summary === existing.summary
+                && merged.reused === existing.reused && merged.failure === existing.failure) {
                 return {};
             }
             return {
@@ -825,6 +855,8 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             return;
         }
         const patch: Partial<StepRuntime> = {};
+        if (typeof event.reused === 'boolean') patch.reused = event.reused;
+        if (event.failure) patch.failure = normalizeOrchestrationFailure(event.failure);
         const status = coerceStepStatus(event.status);
         if (status) {
             patch.status = status;
@@ -879,6 +911,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                 finishedAt: Date.now(),
                 intentSummary: summary,
                 origin: 'local',
+                attempt: state.runRecovery[runId],
             };
             const existing = state.history[run.conversationId] ?? [];
             const nextEntries = [entry, ...existing].slice(0, MAX_HISTORY_PER_CONVERSATION);
@@ -889,6 +922,15 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
 
             return {
                 inFlight,
+                plans: {
+                    ...state.plans,
+                    ...(state.plans[scopeKey(run.conversationId, run.turnId)]?.run_id === runId ? {
+                        [scopeKey(run.conversationId, run.turnId)]: {
+                            ...state.plans[scopeKey(run.conversationId, run.turnId)],
+                            status: outcome,
+                        },
+                    } : {}),
+                },
                 history: { ...state.history, [run.conversationId]: nextEntries },
                 pinnedRunId,
             };
@@ -927,6 +969,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
         }
         set((state) => {
             const entries: RunHistoryEntry[] = [];
+            const runRecovery = { ...state.runRecovery };
             const seen = new Set<string>();
             const persistedStatus = new Map<string, PlanStatus | null>();
             for (const run of runs ?? []) {
@@ -935,6 +978,11 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                     continue;
                 }
                 seen.add(entry.runId);
+                runRecovery[entry.runId] = {
+                    ...runRecovery[entry.runId],
+                    ...normalizeOrchestrationAttempt(run),
+                    status: run.status,
+                };
                 persistedStatus.set(entry.runId, entry.planStatus ?? null);
                 entries.push(entry);
             }
@@ -956,7 +1004,8 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                     continue;
                 }
                 const status = persistedStatus.get(run.runId);
-                if (status && NON_TERMINAL_PLAN_STATUSES.has(status)) {
+                if ((status && NON_TERMINAL_PLAN_STATUSES.has(status))
+                    || isOrchestrationRunPending(runRecovery[run.runId] ?? {})) {
                     continue;
                 }
                 if (!changed) {
@@ -971,6 +1020,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
 
             return {
                 inFlight,
+                runRecovery,
                 hydratedHistory: {
                     ...state.hydratedHistory,
                     [conversationId]: entries.slice(0, MAX_HISTORY_PER_CONVERSATION),
@@ -1008,6 +1058,8 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                 runtime[stepId] = {
                     status,
                     summary: typeof record.summary === 'string' ? record.summary : '',
+                    reused: record.reused === true,
+                    failure: normalizeOrchestrationFailure(record.failure),
                 };
             }
 

--- a/docs/admin/orchestration.md
+++ b/docs/admin/orchestration.md
@@ -304,7 +304,9 @@ Opening a conversation on a second device rebuilds the orchestration panel from 
 server holds. A user who plans on a laptop and then opens the same conversation on a
 phone sees the same list of runs, can expand any of them, and can read the steps and
 results of a run they were not present for. Runs opened this way are shown as a record:
-they can be read but not edited or run again, because they have already happened.
+they cannot be edited or directly executed again. Since **0.261.105**, an incomplete
+run with valid checkpoints can instead prepare a separate, user-approved recovery
+attempt that reuses its completed results.
 
 A plan that was still waiting for approval when the user moved is the one case that stays
 actionable. It reappears as a plan the user can approve, edit or discard, so a plan is
@@ -314,9 +316,33 @@ nothing starts running on a device where nobody was watching. And if the plan wa
 approved elsewhere in the meantime, approving it again is refused rather than run twice,
 and the conversation reloads to show the answer that already exists.
 
-A run that was interrupted — the browser closed, the device slept, the network dropped
-mid-run — is shown as interrupted rather than silently disappearing or appearing to still
-be working.
+A closed browser or dropped connection does not prove that server execution stopped.
+The interface checks the saved attempt rather than treating transport loss as user
+cancellation or automatically running the work again.
+
+## Failure explanations and checkpoint recovery
+
+Implemented in version **0.261.105**, tracked in `application/single_app/config.py`.
+Execution failures and measured timeouts are reported in the conversation and Run
+view. If the answering model also fails, an application-generated status explanation
+still describes the incomplete work. Errors are not classified from integration
+names or exception-message keywords.
+
+Completed step results are saved in the existing orchestration Cosmos containers.
+No new storage connection or settings switch is required. **Retry from failed step**
+uses these results with the same effective plan and current authorization, rather
+than invoking the planner or repeating the whole request.
+
+Retry is always deliberate, even under Auto approval. If a failed agent/action
+may already have changed an external system, the user must acknowledge that the
+step's internal effects could repeat. Checkpoints do not restore an agent's
+individual tool calls, and cannot guarantee exactly-once remote execution.
+
+A live execution cannot be retried. Missing, incompatible, or unauthorized
+checkpoints block recovery rather than causing completed actions to run again.
+Older runs without full checkpoints remain readable but require a new plan.
+Checkpoint payloads are removed on conversation deletion, including bulk
+deletion and archive-and-remove; existing archived messages are unaffected.
 
 ## Common tasks
 
@@ -356,7 +382,10 @@ be working.
 | A plan proposed reading a link but found nothing | The link was not available in the eligible user-authored context. | Paste the URL into the current request. Assistant-generated links and omitted historical text do not authorize page reads. |
 | Earlier runs are missing after switching devices | The conversation list has loaded but its run history has not been fetched yet, or the fetch failed. | The orchestration panel shows its own loading and retry states. If retrying keeps failing, check that the user can reach `/api/v2/orchestration/runs` and is the owner of the conversation. |
 | A restored plan will not run | It was already approved on the other device. | This is expected. The conversation reloads to show the answer that run produced. |
-| A run is shown as interrupted | The browser or device that started it went away before the run finished. | Ask the user to send the question again. An interrupted run is a record of what happened, not a run that can be continued. |
+| A step reports a timeout or failure | Execution hit a recorded time limit or an operation failed. | Read the conversation/Run explanation. Address the reported dependency or limit, then use Retry from failed step when recovery is available. |
+| A connection was interrupted | The browser cannot yet confirm the server's execution state. | Check the existing run. Do not resend the request while that attempt may still be active. |
+| Retry requires confirmation | An agent/action may have performed external effects before it failed. | Review those effects before confirming. Retry reexecutes that failed step, not its internal tool-call checkpoint. |
+| A saved run cannot be resumed | Checkpoints are absent or invalid, relevant context/access changed, or a newer/live attempt exists. | Follow the recovery explanation. Open the current attempt or create a new plan as appropriate; do not infer results from old summaries. |
 
 ## Related
 
@@ -367,3 +396,4 @@ be working.
 - [Create an action]({{ '/guides/create-an-action/' | relative_url }})
 - [Actions reference]({{ '/reference/actions/' | relative_url }})
 - [Workflow settings]({{ '/admin/workflow/' | relative_url }})
+- [Recover a failed run]({{ '/guides/review-and-edit-orchestration-plans/#recover-from-a-failed-run' | relative_url }})

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Orchestration
 
-**Version: 0.261.104** (tracked in `application/single_app/config.py`)
+**Version: 0.261.105** (tracked in `application/single_app/config.py`)
 
 **Implemented in version: 0.261.086**
 **Knowledge phase added in version: 0.261.089**
@@ -13,6 +13,7 @@
 **Approval preference persistence fixed in version: 0.261.101**
 **Conversational plan editing implemented in version: 0.261.102**
 **Capability-aware planning and reasoning compatibility fixed in version: 0.261.104**
+**Failure communication and checkpoint recovery implemented in version: 0.261.105**
 
 ## Overview
 
@@ -421,6 +422,25 @@ An action is also resolved and authorized at execution and before subsequent fun
 calls. Revocation, definition changes, cancellation or a failed operation stop further
 action calls instead of silently substituting an agent or another integration.
 
+#### Failures and resumable attempts
+
+Since **0.261.105**, measured timeouts are distinct from explicit Stop. Safe
+failure facts reach the final response, and an application-generated status
+message reports incomplete work if the answering model cannot finish. The
+conversation does not depend on a successful model call to explain an execution
+failure.
+
+Completed steps save full reusable results in private, versioned checkpoints.
+**Retry from failed step** creates a linked attempt of the same effective plan
+and restores valid completed results without calling their adapters again.
+Current source, context, agent/action, and model access are rechecked. Invalid
+checkpoints block recovery instead of causing a silent full-plan replay.
+
+An agent/action may have performed external effects inside its failed step.
+Retrying that step requires confirmation when effects could repeat. Recovery
+does not restore the agent's internal tool loop and never runs automatically.
+See [Checkpoint recovery](ORCHESTRATION_CHECKPOINT_RECOVERY.md).
+
 #### The worker-thread boundary
 
 `execute_plan` runs in a `threading.Thread` so progress can stream while work happens. That
@@ -458,6 +478,8 @@ without starting its steps or adding messages to the main conversation.
 | `/api/v2/orchestration/run` | POST | Executes an approved plan, streaming step progress and the answer. |
 | `/api/v2/orchestration/cancel/<run_id>` | POST | Asks a running plan to stop. |
 | `/api/v2/orchestration/runs` | GET | Every run in a conversation, oldest first, for the drawer's map view. |
+| `/api/v2/orchestration/runs/<run_id>` | GET | One saved plan with its outcome and safe recovery eligibility. |
+| `/api/v2/orchestration/runs/<run_id>/retry` | POST | Idempotently prepares a linked recovery attempt, with confirmation for uncertain external effects. |
 | `/api/v2/orchestration/runs/<run_id>/editor` | GET | Current editor state and paged revision history. |
 | `/api/v2/orchestration/runs/<run_id>/edit` | POST | Hold an unexecuted plan for manual approval before editing. |
 | `/api/v2/orchestration/runs/<run_id>/revisions` | POST | Ask the planner for a change, answer its question, restore a version, or discard a pending change. |
@@ -481,6 +503,12 @@ emits, so `ThoughtTracker` persistence and the client's activity-lane rendering 
 unchanged and a live run draws identically to a reloaded one. Orchestration adds the
 `step_type` values `orchestration_triage`, `orchestration_planning`, `orchestration_step`
 and `orchestration_synthesis`, each carrying `activity.lane_key = "orchestration"`.
+
+Execution terminal events also retain the actual outcome, safe failure
+information, and attempt/recovery identifiers. A final explanatory message does
+not imply that every step succeeded. The same information is saved with the
+assistant message and restored from history. A dropped stream is reconciled
+against the saved run rather than treated as proof that the server cancelled it.
 
 Three event types are genuinely new, because nothing existing meant the same thing:
 `orchestration_plan`, `orchestration_elicitation` and `orchestration_step`.
@@ -611,6 +639,8 @@ See [the Orchestration settings page](../../admin/orchestration.md) for the full
 | `functions_orchestration_adapters.py` | Capability adapters over existing functions |
 | `functions_orchestration_executor.py` | Step engine, budgets, cancellation, re-authorization |
 | `functions_orchestration_runs.py` | Run and step persistence |
+| `functions_orchestration_checkpoints.py` | Private reusable result payloads, committed manifests, and integrity checks |
+| `functions_orchestration_recovery.py` | Linked retry attempts, execution ownership, and guarded recovery |
 | `functions_orchestration_events.py` | Stream event builders |
 | `functions_orchestration_models.py` | Authorized model selection, endpoint clients, completion parameters and safe model metadata |
 | `route_backend_orchestration.py` | The V2 endpoints, conversation and message persistence |
@@ -720,6 +750,9 @@ research-selection rate is not itself a quality improvement.
   each agent step pays that cost in full.
 - **Steps run sequentially.** The executor orders steps by dependency but does not run
   independent steps in parallel.
+- **Recovery is step-level.** It reuses valid completed checkpoints, not an agent's
+  internal tool-loop state. An uncertain failed agent/action requires confirmation
+  before retry. Older runs without checkpoints cannot be retroactively resumed.
 - **Workflows do not yet execute against this engine.** The run record was shaped with that
   in mind, but the two remain separate.
 
@@ -727,6 +760,8 @@ research-selection rate is not itself a quality improvement.
 
 - [Orchestration settings](../../admin/orchestration.md)
 - [Chat Orchestration Action Access](CHAT_ORCHESTRATION_ACTIONS.md)
+- [Checkpoint recovery](ORCHESTRATION_CHECKPOINT_RECOVERY.md)
+- [Error communication fix](../fixes/ORCHESTRATION_ERROR_COMMUNICATION_FIX.md)
 - [Conversation context fix](../fixes/ORCHESTRATION_CONVERSATION_CONTEXT_FIX.md)
 - [Model selection fix](../fixes/ORCHESTRATION_MODEL_SELECTION_FIX.md)
 - `docs/explanation/release_notes.md`

--- a/docs/explanation/features/ORCHESTRATION_CHECKPOINT_RECOVERY.md
+++ b/docs/explanation/features/ORCHESTRATION_CHECKPOINT_RECOVERY.md
@@ -1,0 +1,235 @@
+# Orchestration Checkpoint Recovery
+
+**Version: 0.261.105**
+
+Implemented in version: **0.261.105**, recorded in
+`application/single_app/config.py`.
+
+## Overview
+
+An orchestration failure should explain what could not finish without discarding
+work that already succeeded. Checkpoint recovery saves completed step results and
+uses them when the user chooses **Retry from failed step**.
+
+For example, if document search succeeds and a later agent call times out, retry
+uses the saved search result instead of searching again. The failed agent step
+runs again, its dependents can proceed, and the answering step uses the combined
+results.
+
+Recovery applies to V2 orchestration. It does not change ordinary-agent chat,
+select a replacement agent, or add automatic retries.
+
+## Dependencies and configuration
+
+The existing `enable_chat_orchestration` setting enables the workflow. Each
+capability, source, agent, action, and model must still be enabled and accessible
+to the user. Retry does not grant additional permissions.
+
+Checkpoints use the existing `orchestration_runs` and
+`orchestration_run_steps` Cosmos containers. No separate Blob Storage connection,
+new deployment resource, or recovery preference is required.
+
+Existing execution limits apply to newly executed work. Reusing a saved result
+is not another tool invocation. Retry does not raise the failed step's timeout.
+
+## Understand the failure before retrying
+
+The conversation and Run view identify the failed operation and its known
+reason. An observed time limit is reported as a timeout, not as cancellation by
+the user. A provider status can be included when the runtime actually received
+it; the application does not guess that a service is offline from error prose.
+
+Authorized partial results remain available. If the answering model also fails,
+an application-generated status explanation reports the incomplete work rather
+than leaving an empty assistant turn.
+
+If message storage is unavailable, the interface explicitly marks the visible
+explanation as not saved. It does not claim that an unsaved message will survive
+a reload.
+
+A run can reach a terminal execution status before its final message finishes
+saving. The interface keeps checking during that interval. If the worker stops
+before publication can be confirmed, the interface reports that uncertainty
+rather than claiming that a message was definitely not saved.
+
+**Stop** requests server cancellation. Losing the browser connection is different:
+the server may still be working. The interface reconciles the saved run before
+offering recovery instead of automatically starting another execution.
+
+## Resume a failed request
+
+1. Read the failure explanation in the conversation or open its Plan/Run view.
+2. Select **Retry from failed step** when saved progress is recoverable.
+3. Review which completed steps will be reused and which work will execute.
+4. If an agent or action may have already changed an external system, acknowledge
+   the warning before retrying that step.
+5. Follow the new attempt. Reused steps are labelled **Reused saved result**, and
+   the answer is generated from saved and newly completed work.
+
+Retry creates a linked attempt of the same effective plan. It retains the
+original question, chosen agent and model, accepted clarification answers, source
+restrictions, and saved conversation context. It does not duplicate the user
+message or ask the planner to choose a different approach.
+
+The original resolved request is retained, including a time window resolved
+during planning. Ask a new question when a different time range or different
+approach is needed.
+
+Retries require an explicit user action even when normal plan approval is Auto
+or countdown-based. Reloading a conversation does not approve a retry. Earlier
+attempts remain inspectable, but cannot create competing branches after a newer
+attempt exists.
+
+If a retry was prepared but not yet executed when the connection was lost, it
+stays paused. Open it and use **Run prepared retry** to start that saved attempt.
+**Check saved status** reconciles uncertain execution state, while **View current
+attempt** and **View previous attempt** navigate history without executing work.
+
+## External effects and checkpoint boundaries
+
+A checkpoint represents one completed orchestration step. An agent step can
+contain several internal tool calls; recovery does not restore that internal
+tool loop.
+
+If an agent changed an external record and then failed, retrying that agent step
+could repeat the change. The same uncertainty exists if external work completed
+but saving its checkpoint failed. The confirmation explains this before
+execution. Unknown replay safety is treated conservatively rather than inferred
+from an integration's name or the wording of the task.
+
+Previously completed plan steps are not silently reexecuted. If one of their
+checkpoints is no longer valid, recovery stops with an explanation instead of
+turning Retry into a full-plan restart.
+This also applies when a retry worker stops before copying inherited results:
+completed work remains bound to its saved checkpoint in an earlier attempt.
+
+## Durable state and validation
+
+Completed results include their evidence, notes, citations, artifact references,
+required context changes, and execution provenance. A summary alone cannot
+reconstruct these values.
+
+Payloads are split into bounded records and published through a committed
+manifest. Reconstruction checks their identity, schema, size, completeness, and
+integrity. An incomplete or damaged payload is not treated as an empty successful
+result. Each checkpoint is limited to 8 MiB of serialized payload across at most
+64 chunks. Exceeding that bound fails checkpoint persistence explicitly rather
+than truncating the result.
+
+Each checkpoint is bound to its effective plan, step inputs, dependency context,
+and relevant sources. This includes context an adapter actually consumes, such
+as earlier findings supplied to an action, not just declared step dependencies.
+
+Current authorization is checked before reuse and before publication of the
+answer. Changes to referenced conversation messages, source availability, agent
+or action definitions, or model access can make recovery unavailable. The
+application does not substitute a source or model to bypass that failure.
+
+Runtime clients, credentials, callbacks, and raw saved-memory prompts are not
+checkpoints. Runtime identity and authorized memory are rebuilt for each
+attempt. Private payloads remain server-side; browser responses expose safe
+status and recovery summaries.
+
+Checkpoint payloads are removed when the owning conversation is deleted,
+including bulk deletion and archive-and-remove. Existing archived messages keep
+their normal behavior, but archived conversations do not retain executable
+recovery state.
+
+## Attempts and concurrency
+
+Retry preparation is idempotent. Repeating the same submission after a lost
+response returns the saved attempt rather than creating another one. Conditional
+writes prevent two tabs from preparing competing retries of the same attempt.
+
+Execution ownership is renewed while work is running. Recovery cannot take over
+a live execution, and an expired worker cannot publish a competing result into a
+replacement attempt. A browser disconnect alone is not evidence that ownership
+expired.
+
+Terminal messages have a deterministic per-attempt identity. If a message write
+commits but its acknowledgement is lost, publication is reconciled against the
+saved message and its guard before reporting a storage failure. This avoids
+blocking an otherwise valid retry merely because the write response was lost.
+
+These safeguards do not promise exactly-once execution in an external service.
+Already submitted remote work may continue after a local timeout or Stop, which
+is why uncertain agent/action retries require confirmation.
+
+## API and file structure
+
+All endpoints use the existing authenticated orchestration Blueprint and check
+ownership. A caller cannot submit a replacement plan or checkpoint payload.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v2/orchestration/runs/<run_id>` | Read a saved plan, outcome, and safe recovery eligibility without approving or starting work. |
+| `GET /api/v2/orchestration/runs/<run_id>/steps` | Read step status, failure, and reused-result information, not private checkpoint contents. |
+| `POST /api/v2/orchestration/runs/<run_id>/retry` | Prepare one linked attempt using a submission ID, expected recovery version, and any required external-effect confirmation. |
+| `POST /api/v2/orchestration/run` | Execute the saved attempt after the user's explicit retry action. |
+| `POST /api/v2/orchestration/cancel/<run_id>` | Request server-side cancellation. |
+
+Retry preparation accepts `conversation_id`, a stable `submission_id`,
+`expected_version` from the current recovery detail, and
+`confirm_external_effects`. The server derives the executable plan and
+checkpoint set; these fields cannot replace step arguments or broaden access.
+Executing the prepared child omits `edits` and uses the new child's returned
+`plan.edit_version` as `expected_version` when present. Do not substitute the
+source plan's version or the recovery token used during preparation. The normal
+conditional execution claim still prevents stale or duplicate approvals.
+
+Execution terminal events and saved assistant metadata retain the run, turn,
+attempt, outcome, safe failure, and recovery information. A completed answer
+message does not erase a partial or failed execution outcome.
+
+Modern terminal run projections also expose `finalization_status`: `pending`
+while publication is in progress, `saved` after confirmed persistence, `failed`
+after an explicit persistence failure, or `interrupted` when a worker expired
+without confirmed publication. `message_saved` is a boolean only when the result
+is known. Clients must not stop reconciling merely because the execution
+`status` is terminal while finalization is still pending.
+
+| File | Responsibility |
+| --- | --- |
+| `functions_orchestration_schema.py` | Shared step results and failure information. |
+| `functions_orchestration_executor.py` | Execution reasons, checkpoint restore, dependency order, and final reporting. |
+| `functions_orchestration_checkpoints.py` | Private checkpoint payloads, manifests, and integrity checks. |
+| `functions_orchestration_recovery.py` | Attempt ownership, conditional recovery, and replay-safety decisions. |
+| `route_backend_orchestration.py` | Retry API, safe projections, and persistent assistant messages. |
+| `orchestrationController.ts` and `orchestrationStore.ts` | Live and restored recovery state in the V2 interface. |
+
+## Coverage and limitations
+
+`functional_tests/test_orchestration_checkpoint_recovery.py` exercises measured
+timeouts, explicit Stop, safe error content, model-independent failure reporting,
+completed-step reuse, checkpoint integrity, storage failures, concurrent retry
+claims, chained worker interruptions, lost message-write acknowledgements, and
+current authorization. The existing executor and run-hydration
+regressions continue to protect ordering and browser projection boundaries.
+
+`ui_tests/test_v2_orchestration_recovery.py` uses the existing Playwright harness
+for visible failures, confirmation, retry, reused results, and restored history.
+It also covers terminal publication still in progress after a disconnect or
+reload, including confirmation of the final saved message without another click.
+`ui_tests/test_v2_orchestration_recovery_backend.py` forwards real component
+requests through the Flask routes using
+`functional_tests/test_support/orchestration_recovery.py`. It covers checkpoint
+reuse and visible failures when answer-message storage is unavailable. Service
+boundaries are deterministic; tests do not depend on an unavailable production
+integration.
+
+Checkpoints add storage writes proportional to completed output size. Large
+results are chunked rather than silently truncated. Reuse avoids repeating
+completed model/tool work, but each retry can incur costs for its newly executed
+steps.
+
+Older runs without full checkpoints cannot be retroactively resumed. Their
+history remains readable, and the interface explains why a new plan is required.
+There is no automatic full-plan fallback, internal agent tool-call continuation,
+or guarantee that remote effects can be undone.
+
+## Related
+
+- [Chat orchestration](CHAT_ORCHESTRATION.md)
+- [Error communication fix](../fixes/ORCHESTRATION_ERROR_COMMUNICATION_FIX.md)
+- [Review, edit, and recover plans](../../guides/review-and-edit-orchestration-plans.md)
+- [Orchestration settings](../../admin/orchestration.md)

--- a/docs/explanation/fixes/ORCHESTRATION_ERROR_COMMUNICATION_FIX.md
+++ b/docs/explanation/fixes/ORCHESTRATION_ERROR_COMMUNICATION_FIX.md
@@ -1,0 +1,97 @@
+# Orchestration Error Communication Fix
+
+**Version: 0.261.105**
+
+Fixed in version: **0.261.105**, recorded in
+`application/single_app/config.py`.
+
+## Issue
+
+An orchestration plan could correctly choose an agent, encounter a time limit or
+execution failure, and leave the conversation with no explanation. The Run view
+could show the agent and answering step as cancelled even when the user had not
+pressed Stop.
+
+The equivalent direct-agent request could explain the service failure. The gap
+was in orchestration execution and reporting, not in selecting a particular
+integration.
+
+## Root cause
+
+The executor combined the user's cancellation signal with step and total
+deadlines in one callback. Scoped agent execution interpreted that callback as
+`AgentExecutionCancelled`, and the adapter returned a cancelled step.
+
+A cancelled step cancelled the rest of the plan, including `respond`. The route
+then returned its cancellation event before reaching the normal assistant-message
+save path. Other execution failures were replaced by a generic error event, and
+failed-step details were not consistently available to final synthesis.
+
+The browser compounded the gap: empty cancellations added no message, failures
+used a transient stream error, and a settled inline plan card could disappear.
+Its completion handler also treated a final message as successful completion
+regardless of the server's execution outcome.
+
+## Changes
+
+Execution now distinguishes explicit Stop, measured deadlines, and unexpected
+interruption. Failure information uses application-owned reason codes and safe
+messages. Provider detail is included only when structured metadata supports it;
+there are no integration-specific branches or error-text keyword rules.
+
+The main conversation and Run view retain an explanation of incomplete work.
+Safe failure context reaches normal answering, with an application-generated
+status explanation when the answering model cannot finish. Authorized partial
+results can remain useful without falsely marking every step successful.
+
+Execution outcome and attempt identifiers travel through terminal events, saved
+assistant metadata, and run-history projections. A dropped browser stream does
+not prove server cancellation. Stop uses the server cancellation path, while
+connection recovery checks the already-running attempt.
+
+Reconciliation also waits for final-message publication, not just a terminal
+execution status. A committed message whose write acknowledgement was lost is
+confirmed from durable storage rather than incorrectly reported as unsaved.
+
+The associated [checkpoint recovery feature](../features/ORCHESTRATION_CHECKPOINT_RECOVERY.md)
+adds **Retry from failed step** without silently replaying successful plan steps.
+Retries of agents/actions with uncertain external effects require confirmation.
+
+## Affected components
+
+| Component | Change |
+| --- | --- |
+| Agent execution context/runtime | Distinguish a measured delegation deadline from a user cancellation. |
+| Orchestration schema, adapters, and executor | Retain structured failure facts, safe final reporting, and completed-step recovery state. |
+| Orchestration routes and event builders | Save failure/status messages and expose consistent live/history outcomes. |
+| V2 orchestration transport/controller and chat stores | Preserve failure messages and actual outcomes rather than dropping empty cancellations or hardcoding success. |
+| Plan/Run views and message actions | Keep explanations and guarded retry controls available after execution settles. |
+
+## Coverage and impact
+
+`functional_tests/test_orchestration_checkpoint_recovery.py` uses fake providers
+and clocks to distinguish timeout from user Stop. It also exercises failed final
+synthesis, successful text that merely mentions errors, secret-bearing exception
+sentinels, history restoration, and retry invocation counts.
+Crash-boundary coverage checks inherited completed results across multiple
+attempts and terminal-message writes with lost acknowledgements.
+`ui_tests/test_v2_orchestration_recovery.py` and
+`ui_tests/test_v2_orchestration_recovery_backend.py` cover the visible recovery
+workflow and real browser-to-Flask integration. Existing
+`functional_tests/test_orchestration_executor.py`,
+`functional_tests/test_orchestration_adapter_contract.py`, and
+`functional_tests/test_orchestration_run_hydration_routes.py` cover the shared
+execution and projection boundaries.
+
+| Before | After |
+| --- | --- |
+| A deadline could cancel the answering step and leave an empty turn. | The affected operation has an honest failure/timeout status and an explanation independent of the answering model. |
+| An execution error could disappear when the browser reloaded. | Saved outcome metadata and conversation messages support restored failure feedback. |
+| A final message implied that the whole run succeeded. | Partial/failed execution remains distinguishable from successful completion. |
+| The apparent retry path could resend ordinary chat or require asking again. | Recoverable orchestration failures use saved completed steps and a linked attempt. |
+| Losing a browser stream looked like stopping the server. | The interface reconciles server state and does not automatically replay potentially active work. |
+| A terminal status could be mistaken for finished message persistence. | The interface continues checking until publication is saved, explicitly failed, or interrupted. |
+
+Ordinary direct-agent chat and agent selection remain unchanged. Older runs
+without recorded reasons or checkpoints remain readable, but the application
+does not invent a historical cause or reconstruct missing results from summaries.

--- a/docs/guides/review-and-edit-orchestration-plans.md
+++ b/docs/guides/review-and-edit-orchestration-plans.md
@@ -4,7 +4,7 @@ title: "Review and edit orchestration plans"
 description: "Refine proposed work with the planner before running it."
 section: "Guides"
 audience: user
-version: "0.261.104"
+version: "0.261.105"
 ---
 
 ## Decide what should run
@@ -129,8 +129,51 @@ continuing. An outdated approval cannot run a superseded plan.
 If Cancel discovers a newer pending change, the editor shows that change without
 cancelling it. Review it before explicitly choosing Cancel again.
 
+## Recover from a failed run
+
+Since **0.261.105**, an execution failure remains visible in the conversation and
+Run view. The explanation distinguishes a measured timeout from a user-requested
+Stop and describes the work that could not finish. If answering also fails, a
+status explanation still reports the incomplete request.
+
+Use **Retry from failed step** when the run has recoverable saved progress.
+Review which steps will be reused and which work will execute. Completed steps
+are restored from checkpoints and labelled **Reused saved result**; retry does
+not ask the planner to choose a new agent or start the whole plan again.
+
+An agent step may have performed several tool calls before failing. If retry
+could repeat external effects, read and confirm the warning before continuing.
+The retry resumes at the orchestration-step boundary, not inside that agent's
+tool loop.
+
+The new attempt retains the original question and effective plan, including
+source restrictions, clarification answers, and the selected model. It does not
+duplicate your question. The earlier attempt remains available in history.
+Retry always requires your action, even when normal approval is Auto or timed.
+
+A browser disconnect does not mean the server stopped. Let the interface check
+the existing attempt before retrying. A live attempt cannot be retried, and a
+lost retry response is recovered without starting a second copy.
+
+The Run view can finish before its final conversation message has been saved.
+The interface keeps checking during that interval instead of prematurely
+reporting a missing message. If saving fails, or the server stops before saving
+can be confirmed, the visible status explains the difference.
+
+Use **Check saved status** if the connection still cannot confirm the outcome.
+If retry preparation was saved but execution never started, open that attempt
+and select **Run prepared retry**. It remains paused across reloads. **View
+current attempt** and **View previous attempt** navigate the linked history
+without running work.
+
+If sources, permissions, or saved context changed, or an older run has no full
+checkpoints, recovery explains why it cannot continue. Create a new plan in that
+case; the application will not quietly rerun completed actions to fill a gap.
+Editing an already-started plan remains unavailable.
+
 ## Related
 
 - [Chat orchestration](https://github.com/microsoft/simplechat/blob/main/docs/explanation/features/CHAT_ORCHESTRATION.md)
 - [Plan editing architecture](https://github.com/microsoft/simplechat/blob/main/docs/explanation/features/V2_ORCHESTRATION_PLAN_EDITING.md)
+- [Checkpoint recovery architecture](https://github.com/microsoft/simplechat/blob/Development/docs/explanation/features/ORCHESTRATION_CHECKPOINT_RECOVERY.md)
 - [Orchestration settings]({{ '/admin/orchestration/' | relative_url }})

--- a/docs/reference/chat-controls.md
+++ b/docs/reference/chat-controls.md
@@ -4,7 +4,7 @@ title: "Chat interface controls"
 description: "Reference for every documented control in the SimpleChat chat interface."
 section: "Reference"
 audience: user
-version: "0.261.104"
+version: "0.261.105"
 ---
 
 ## How to use this reference
@@ -244,3 +244,29 @@ plan rather than editing the main chat message. See
 | Ask planner | Sends a change request to the planner for a validated revision, or answers its scoped clarification. | Add a permitted step, remove work, or refine the task without duplicating the main conversation. | Same as Edit; existing capability and source permissions apply |
 | History and restore | Shows previous plan versions and creates a newly validated current version when restoring one. | Return to an earlier approach without deleting later history. | Same as Edit |
 | Run after editing | Executes the saved current revision only after explicit approval. Closing the editor does not approve it. | Start the work once its steps and sources match your intent. | Same as Edit; no revision or clarification may be pending |
+
+## Orchestration failure recovery (V2 interface)
+
+Implemented in **0.261.105**. A failed run keeps an explanation in the conversation
+and Run view instead of silently cancelling the answering step. Recovery uses the
+saved effective plan, not the current composer selections or a new planner call.
+
+| Control | What it does | Why you would use it | Enabled by |
+| --- | --- | --- | --- |
+| Retry from failed step | Creates a linked attempt that restores valid completed-step results and executes the incomplete work. | Recover after a failure without repeating successful plan steps or duplicating the question. | `enable_chat_orchestration`, current access, and recoverable saved checkpoints |
+| Confirm retry / Cancel | Confirms the possible external effects of retrying a failed agent/action, or dismisses the confirmation without executing it. | Decide whether it is safe to repeat the failed step's internal tool activity. | A recoverable attempt that requires external-effect confirmation |
+| Run prepared retry | Starts a recovery attempt that was already prepared but has not executed. | Continue after preparation was saved but execution was interrupted by navigation or connection loss. | An unstarted saved recovery attempt |
+| Review saved attempt | Opens the selected attempt in the Plan/Run view. | Inspect the failure, completed steps, and remaining work without editing or rerunning history. | A saved orchestration attempt |
+| View current attempt / View previous attempt | Opens a linked execution attempt rather than starting another one. | Follow recovery history and avoid retrying an older attempt that already has a successor. | Linked recovery attempts |
+| Check saved status | Reconciles the displayed state with the existing server execution. | Find out whether work finished when the browser connection was lost or recovery details could not load. | An execution-status or recovery-detail error |
+| Stop execution | Requests server cancellation of the potentially active attempt. | Stop work even when its streaming connection was interrupted. | An interrupted connection with a tracked in-flight attempt |
+
+Steps restored from checkpoints show **Reused saved result**. Retry is always
+manual, including when normal approval is Auto or timed. An older attempt cannot
+create a competing retry after a newer attempt has been prepared.
+
+Stop requests cancellation on the server. A connection loss instead requires
+checking the existing execution; it must not automatically start another one.
+When a checkpoint or source is unavailable, the interface explains why recovery
+is blocked rather than turning Retry into a full-plan replay. See
+[Review, edit, and recover plans]({{ '/guides/review-and-edit-orchestration-plans/' | relative_url }}).

--- a/functional_tests/route_tests/test_route_blueprint_policy_inventory.py
+++ b/functional_tests/route_tests/test_route_blueprint_policy_inventory.py
@@ -2,7 +2,7 @@
 # test_route_blueprint_policy_inventory.py
 """
 Functional test for route blueprint policy inventory.
-Version: 0.261.102
+Version: 0.261.105
 Implemented in: 0.242.069
 Plan editor policy coverage: 0.261.102
 
@@ -298,6 +298,7 @@ def test_plan_editor_routes_keep_the_orchestration_security_policy() -> None:
         "/api/v2/orchestration/runs/<run_id>/editor": "orchestration_plan_editor",
         "/api/v2/orchestration/runs/<run_id>/edit": "orchestration_begin_plan_edit",
         "/api/v2/orchestration/runs/<run_id>/revisions": "orchestration_revise_plan",
+        "/api/v2/orchestration/runs/<run_id>/retry": "orchestration_retry",
     }
     routes = {
         route.path: route for route in iter_route_functions()

--- a/functional_tests/test_agent_delegation_runtime.py
+++ b/functional_tests/test_agent_delegation_runtime.py
@@ -1,7 +1,7 @@
 # test_agent_delegation_runtime.py
 """Executable delegation runtime regression tests.
 
-Version: 0.261.093
+Version: 0.261.105
 Implemented in: 0.261.093
 
 Real execution contexts, runtime, plugin and activity logger run against mock
@@ -246,7 +246,8 @@ def test_blocked_child_is_interrupted_and_finally_runs(runtime, monkeypatch, rea
             await asyncio.sleep(0.01)
             if reason == "cancel":
                 stopped = True
-            with pytest.raises(runtime.AgentDelegationError):
+            expected = runtime.AgentExecutionCancelled if reason == 'cancel' else runtime.AgentDelegationTimeout
+            with pytest.raises(expected):
                 await asyncio.wait_for(task, 0.5)
 
     asyncio.run(run())

--- a/functional_tests/test_orchestration_adapter_contract.py
+++ b/functional_tests/test_orchestration_adapter_contract.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+# test_orchestration_adapter_contract.py
 """
 Functional test for the orchestration adapter contract.
-Version: 0.261.089
+Version: 0.261.105
 Implemented in: 0.261.087
 
 This is the generalisation of a bug that reached production. A step failed live with
@@ -25,6 +25,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from test_support.app_stubs import APP_ROOT, stubbed_app_imports  # noqa: E402
+from test_support.orchestration_research import stubbed_orchestration_imports  # noqa: E402
 from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 ADAPTERS = 'functions_orchestration_adapters.py'
@@ -356,7 +357,7 @@ def test_request_gates_withhold_what_the_caller_cannot_use():
     """The gates themselves, exercised rather than inspected."""
     print("Testing request gate behaviour...")
     try:
-        with stubbed_app_imports():
+        with stubbed_orchestration_imports():
             from functions_orchestration_registry import resolve_available_capabilities
 
             settings = {

--- a/functional_tests/test_orchestration_checkpoint_recovery.py
+++ b/functional_tests/test_orchestration_checkpoint_recovery.py
@@ -1,0 +1,794 @@
+# test_orchestration_checkpoint_recovery.py
+"""Functional regressions for durable, checkpoint-only orchestration recovery.
+
+Version: 0.261.105
+Implemented in: 0.261.105
+Runs real Flask endpoints, executor, checkpoint codec, conditional batches and
+assistant persistence against AtomicMemoryContainer; no live services.
+"""
+
+import json
+import unittest
+from copy import deepcopy
+from datetime import timedelta
+from types import SimpleNamespace
+import threading
+from unittest.mock import patch
+
+from azure.core.exceptions import AzureError
+
+from test_support.orchestration_recovery import RecoveryFixture, frames
+from test_support.versioning import assert_app_version_at_least
+
+
+class CheckpointRecoveryTests(unittest.TestCase):
+    def _crash_retry(self, fixture, child, phase):
+        manager_type = fixture.route.ExecutionCheckpoints
+        original_initialize = manager_type.initialize
+        original_save = manager_type.save_step
+        namespace = fixture.route.prepare_retry.__globals__
+
+        def crash(manager):
+            manager.lease.close()
+            fixture.runs.items[('conv1', child['run_id'])]['execution_lease']['expires_at'] = (
+                namespace['_now']() - timedelta(seconds=2)
+            ).isoformat()
+            raise namespace['CheckpointError']('ownership_lost')
+
+        def initialize(manager):
+            if phase == 'before_initialize':
+                crash(manager)
+            original_initialize(manager)
+            if phase == 'after_initialize':
+                crash(manager)
+
+        def save(manager, record):
+            original_save(manager, record)
+            if phase == 'after_first_copy' and record['step_id'] == 'a':
+                crash(manager)
+
+        with patch.object(manager_type, 'initialize', initialize), patch.object(manager_type, 'save_step', save):
+            events = frames(fixture.run_attempt(child['plan']))
+        self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events))
+
+    def test_inherited_effect_checkpoints_survive_crashes_and_chained_retries(self):
+        for phase in ('before_initialize', 'after_initialize', 'after_first_copy'):
+            with self.subTest(phase=phase), RecoveryFixture() as fixture:
+                fixture.fail_b = False
+                fixture.model.answer_error = RuntimeError('answer failed')
+                plan = fixture.plan_attempt()
+                fixture.run_attempt(plan)
+                child = fixture.retry(plan['run_id'], confirm_external_effects=False).get_json()['run']
+                self.assertEqual(child['recovery']['reused_step_ids'], ['a', 'b', 'c'])
+                self.assertEqual(child['recovery']['retry_step_ids'], ['answer'])
+                self._crash_retry(fixture, child, phase)
+                detail = fixture.detail(child['run_id'])
+                self.assertEqual(detail['finalization_status'], 'interrupted')
+                self.assertEqual(detail['recovery']['reused_step_ids'], ['a', 'b', 'c'])
+                self.assertEqual(detail['recovery']['retry_step_ids'], ['answer'])
+                self.assertFalse(detail['recovery']['requires_confirmation'])
+                hydrated = fixture.client.get(
+                    f"/api/v2/orchestration/runs/{child['run_id']}/steps?conversation_id=conv1"
+                ).get_json()['steps']
+                self.assertEqual([step['step_id'] for step in hydrated], ['a', 'b', 'c'])
+                self.assertTrue(all(step['status'] == 'completed' and step['reused'] for step in hydrated))
+                self.assertNotIn('payload_digest', json.dumps(hydrated))
+                old_token = fixture.runs.read_item(child['run_id'], 'conv1')['execution_lease']['token']
+                response = fixture.retry(child['run_id'], confirm_external_effects=False)
+                self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+                namespace = fixture.route.prepare_retry.__globals__
+                old_store = namespace['checkpoint_store'](
+                    fixture.runs.read_item(child['run_id'], 'conv1'), lambda: True, token=old_token,
+                )
+                with self.assertRaises(namespace['CheckpointError']):
+                    old_store.initialize()
+                third = response.get_json()['run']
+                self._crash_retry(fixture, third, 'after_initialize')
+                fourth = fixture.retry(third['run_id'], confirm_external_effects=False).get_json()['run']
+                fixture.model.answer_error = None
+                done = next(
+                    event for event in frames(fixture.run_attempt(fourth['plan']))
+                    if event.get('type') == 'orchestration_done'
+                )
+                self.assertEqual(done['status'], 'completed')
+                self.assertEqual(fixture.calls, ['a', 'b', 'c'])
+                record = fixture.runs.read_item(fourth['run_id'], 'conv1')
+                self.assertTrue(all(
+                    step.get('reused_from_run_id') == plan['run_id']
+                    for step in record['execution_steps'] if step['step_id'] != 'answer'
+                ))
+
+    def test_invalid_inherited_checkpoints_block_without_repeating_effects(self):
+        for damage in ('missing_run', 'deleted', 'deleted_checkpoint', 'missing_manifest', 'corrupt_chunk', 'owner', 'turn', 'plan', 'binding', 'digest', 'missing_reference'):
+            with self.subTest(damage=damage), RecoveryFixture() as fixture:
+                fixture.fail_b = False
+                fixture.model.answer_error = RuntimeError('answer failed')
+                plan = fixture.plan_attempt()
+                fixture.run_attempt(plan)
+                child = fixture.retry(plan['run_id'], confirm_external_effects=False).get_json()['run']
+                self._crash_retry(fixture, child, 'after_first_copy')
+                original = fixture.runs.items[('conv1', plan['run_id'])]
+                interrupted = fixture.runs.items[('conv1', child['run_id'])]
+                if damage == 'missing_run':
+                    del fixture.runs.items[('conv1', plan['run_id'])]
+                elif damage == 'deleted':
+                    original['checkpoints_deleted'] = True
+                elif damage == 'deleted_checkpoint':
+                    fixture.steps.items[(plan['run_id'], 'checkpoint:lifecycle')]['deleted'] = True
+                elif damage == 'missing_manifest':
+                    key = next(key for key, row in fixture.steps.items.items()
+                               if key[0] == plan['run_id'] and row.get('step_id') == 'b'
+                               and row.get('record_type') == 'checkpoint_manifest')
+                    del fixture.steps.items[key]
+                elif damage == 'corrupt_chunk':
+                    row = next(row for key, row in fixture.steps.items.items()
+                               if key[0] == plan['run_id'] and row.get('step_id') == 'b'
+                               and row.get('record_type') == 'checkpoint_chunk')
+                    row['data'] = 'invalid private checkpoint bytes'
+                elif damage == 'owner':
+                    original['user_id'] = 'other-user'
+                elif damage == 'turn':
+                    original['turn_id'] = 'other-turn'
+                elif damage == 'plan':
+                    original['plan']['steps'][1]['arguments']['task'] = 'Different external action'
+                elif damage == 'binding':
+                    original['execution_binding'] = 'different-binding'
+                elif damage == 'digest':
+                    interrupted['inherited_checkpoints']['b']['payload_digest'] = 'different-digest'
+                else:
+                    interrupted['inherited_checkpoints'].pop('b')
+                response = fixture.client.post(f"/api/v2/orchestration/runs/{child['run_id']}/retry", json={
+                    'conversation_id': 'conv1', 'submission_id': 'damaged-retry',
+                    'expected_version': interrupted['recovery_version'], 'confirm_external_effects': False,
+                })
+                self.assertIn(response.status_code, (404, 409, 503), response.get_data(as_text=True))
+                self.assertEqual(fixture.calls, ['a', 'b', 'c'])
+                self.assertFalse(interrupted.get('latest_attempt_run_id'))
+                detail = fixture.client.get(
+                    f"/api/v2/orchestration/runs/{child['run_id']}?conversation_id=conv1"
+                )
+                self.assertEqual(detail.status_code, 503)
+                self.assertEqual(detail.get_json()['code'], 'recovery_unavailable')
+
+    def test_inherited_success_does_not_waive_confirmation_for_new_failed_effects(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            child = fixture.retry(plan['run_id']).get_json()['run']
+            fixture.run_attempt(child['plan'])
+            detail = fixture.detail(child['run_id'])
+            self.assertEqual(detail['recovery']['reused_step_ids'], ['a'])
+            self.assertTrue(detail['recovery']['requires_confirmation'])
+            denied = fixture.retry(child['run_id'], confirm_external_effects=False)
+            self.assertEqual(denied.status_code, 409)
+            self.assertEqual(denied.get_json()['code'], 'confirmation_required')
+            self.assertEqual(fixture.calls, ['a', 'b', 'b'])
+
+    def test_lost_publication_and_run_link_acknowledgements_reconcile_saved_message(self):
+        for boundary in ('message', 'run_link', 'lease_release'):
+            with self.subTest(boundary=boundary), RecoveryFixture() as fixture:
+                plan = fixture.plan_attempt()
+                original_replace = fixture.runs.replace_item
+                lost = []
+
+                def replace(item, body, **kwargs):
+                    saved = original_replace(item, body, **kwargs)
+                    if not lost and (
+                        (boundary == 'run_link' and body.get('assistant_message_id'))
+                        or (boundary == 'lease_release' and body.get('assistant_message_id') and not body.get('execution_lease'))
+                    ):
+                        lost.append(True)
+                        raise AzureError('private lost run acknowledgement')
+                    return saved
+
+                def lose_message_ack():
+                    lost.append(True)
+                    raise AzureError('private lost batch acknowledgement')
+
+                if boundary == 'message':
+                    fixture.messages.after_batch = lose_message_ack
+                with patch.object(fixture.runs, 'replace_item', replace):
+                    events = frames(fixture.run_attempt(plan))
+                self.assertTrue(lost)
+                done = next(event for event in events if event.get('type') == 'orchestration_done')
+                detail = fixture.detail(plan['run_id'])
+                self.assertTrue(done['message_saved'])
+                self.assertTrue(detail['message_saved'])
+                self.assertEqual(done['finalization_status'], 'saved')
+                self.assertEqual(detail['finalization_status'], 'saved')
+                self.assertEqual(detail['failure']['code'], 'step_timeout')
+                self.assertTrue(detail['recovery']['eligible'])
+                self.assertEqual(detail['assistant_message_id'], done['message_id'])
+                saved = fixture.messages.read_item(done['message_id'], 'conv1')
+                self.assertEqual(saved['metadata']['orchestration']['finalization_status'], 'saved')
+                self.assertTrue(saved['metadata']['orchestration']['message_saved'])
+                child = fixture.retry(plan['run_id']).get_json()['run']
+                self.assertNotIn('finalization_status', child)
+                self.assertNotIn('message_saved', child)
+                self.assertIsNone(child.get('assistant_message_id'))
+
+    def test_ambiguous_publication_rejects_missing_or_different_durable_documents(self):
+        for damage in ('no_commit', 'missing_message', 'missing_guard', 'read_failure', 'content', 'citations', 'metadata', 'guard_token', 'guard_owner', 'guard_run', 'guard_digest', 'deleted_run', 'expired_run'):
+            with self.subTest(damage=damage), RecoveryFixture() as fixture:
+                plan = fixture.plan_attempt()
+                namespace = fixture.route.prepare_retry.__globals__
+
+                def damage_commit():
+                    guard = fixture.messages.items[('conv1', namespace['_publication_id'](plan['run_id']))]
+                    key = ('conv1', guard['published_message_id'])
+                    if damage == 'missing_message':
+                        del fixture.messages.items[key]
+                    elif damage == 'missing_guard':
+                        del fixture.messages.items[('conv1', guard['id'])]
+                    elif damage == 'read_failure':
+                        fixture.messages.fail_reads = True
+                    elif damage == 'content':
+                        fixture.messages.items[key]['content'] = 'Different saved content'
+                    elif damage == 'citations':
+                        fixture.messages.items[key]['hybrid_citations'] = [{'document_id': 'different-document'}]
+                    elif damage == 'metadata':
+                        fixture.messages.items[key]['metadata']['orchestration']['run_id'] = 'other-run'
+                    elif damage == 'guard_token':
+                        guard['token'] = 'different-worker'
+                    elif damage == 'guard_owner':
+                        guard['user_id'] = 'other-user'
+                    elif damage == 'guard_run':
+                        guard['run_id'] = 'other-run'
+                    elif damage == 'guard_digest':
+                        guard['document_digest'] = 'different-digest'
+                    elif damage == 'deleted_run':
+                        fixture.runs.items[('conv1', plan['run_id'])]['checkpoints_deleted'] = True
+                    elif damage == 'expired_run':
+                        fixture.runs.items[('conv1', plan['run_id'])]['execution_lease']['expires_at'] = '2020-01-01T00:00:00Z'
+                    raise AzureError('private ambiguous publication')
+
+                if damage == 'no_commit':
+                    fixture.messages.before_batch = lambda: setattr(fixture.messages, 'fail_writes', True)
+                else:
+                    fixture.messages.after_batch = damage_commit
+                events = frames(fixture.run_attempt(plan))
+                done = [event for event in events if event.get('type') == 'orchestration_done']
+                self.assertFalse(any(event.get('message_saved') for event in done))
+                stored = fixture.runs.items[('conv1', plan['run_id'])]
+                self.assertFalse(stored.get('assistant_message_id'))
+                if damage not in ('deleted_run', 'expired_run'):
+                    self.assertEqual(done[0]['finalization_status'], 'failed')
+                    self.assertFalse(fixture.detail(plan['run_id'])['recovery']['eligible'])
+                self.assertNotIn('private ambiguous publication', json.dumps(events))
+
+    def test_terminal_publication_projects_pending_until_release_then_saved_or_failed(self):
+        for failure in (False, True):
+            with self.subTest(failure=failure), RecoveryFixture() as fixture:
+                plan = fixture.plan_attempt()
+                pending = []
+
+                def before_publish():
+                    pending.append(fixture.detail(plan['run_id']))
+                    self.assertEqual(pending[-1]['status'], 'failed')
+                    self.assertEqual(pending[-1]['finalization_status'], 'pending')
+                    self.assertIsNone(pending[-1]['assistant_message_id'])
+                    self.assertEqual(pending[-1]['recovery']['reason_code'], 'execution_live')
+                    self.assertFalse(pending[-1]['recovery']['eligible'])
+                    if failure:
+                        fixture.messages.fail_writes = True
+
+                fixture.messages.before_batch = before_publish
+                events = frames(fixture.run_attempt(plan))
+                self.assertEqual(len(pending), 1)
+                done = next(event for event in events if event.get('type') == 'orchestration_done')
+                detail = fixture.detail(plan['run_id'])
+                expected = 'failed' if failure else 'saved'
+                self.assertEqual(done['finalization_status'], expected)
+                self.assertEqual(detail['finalization_status'], expected)
+                self.assertEqual(detail['message_saved'], not failure)
+                if not failure:
+                    message = fixture.messages.read_item(done['message_id'], 'conv1')
+                    self.assertEqual(message['metadata']['orchestration']['finalization_status'], 'saved')
+
+    def test_expired_finalization_and_legacy_projection_do_not_claim_missing_messages(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            record = fixture.runs.items[('conv1', plan['run_id'])]
+            record.update({'status': 'failed', 'started_at': '2020-01-01T00:00:00Z'})
+            legacy = fixture.detail(plan['run_id'])
+            self.assertNotIn('finalization_status', legacy)
+            self.assertNotIn('message_saved', legacy)
+            record.update({
+                'finalization_status': 'pending',
+                'execution_lease': {'token': 'expired-worker', 'expires_at': '2020-01-01T00:00:00Z'},
+            })
+            expired = fixture.detail(plan['run_id'])
+            self.assertEqual(expired['finalization_status'], 'interrupted')
+            self.assertNotIn('message_saved', expired)
+            self.assertIsNone(expired.get('assistant_message_id'))
+
+    def test_application_version(self):
+        assert_app_version_at_least('0.261.105')
+
+    def test_successful_content_about_errors_is_not_a_runtime_failure(self):
+        with RecoveryFixture() as fixture:
+            fixture.fail_b = False
+            fixture.model.answer_response = SimpleNamespace(
+                choices=[SimpleNamespace(finish_reason='stop', message=SimpleNamespace(
+                    content='The log mentions timeout, cancelled, HTTP 504 and error, but the requested inspection succeeded.',
+                ))],
+            )
+            done = next(event for event in frames(fixture.run_attempt(fixture.plan_attempt())) if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'completed')
+            self.assertEqual(done['failures'], [])
+
+    def test_effect_before_checkpoint_failure_requires_confirmation_and_keeps_a(self):
+        with RecoveryFixture() as fixture:
+            fixture.fail_b = False
+            plan = fixture.plan_attempt()
+            def fail_commit(step, context, kwargs):
+                if step['step_id'] == 'b':
+                    fixture.steps.fail_writes = True
+            fixture.before_adapter = fail_commit
+            done = next(event for event in frames(fixture.run_attempt(plan)) if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'failed')
+            self.assertTrue(done['recovery']['requires_confirmation'])
+            self.assertTrue(done['recovery']['eligible'])
+            fixture.steps.fail_writes = False
+            fixture.before_adapter = None
+            response = fixture.retry(plan['run_id'], confirm_external_effects=False)
+            self.assertEqual(response.get_json()['code'], 'confirmation_required')
+            child = fixture.retry(plan['run_id']).get_json()['run']
+            fixture.run_attempt(child['plan'])
+            self.assertEqual(fixture.calls, ['a', 'b', 'b', 'c'])
+
+    def test_committed_checkpoint_is_reused_when_progress_publication_was_lost(self):
+        with RecoveryFixture() as fixture:
+            fixture.fail_b = False
+            fixture.model.answer_error = RuntimeError('answer unavailable')
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            record = fixture.runs.items[('conv1', plan['run_id'])]
+            interrupted = next(step for step in record['execution_steps'] if step['step_id'] == 'b')
+            interrupted.update({'status': 'running', 'checkpoint_available': False, 'effects_uncertain': True})
+            fixture.steps.items[(plan['run_id'], f"{plan['run_id']}:b")].update(interrupted)
+            detail = fixture.detail(plan['run_id'])
+            self.assertEqual(detail['recovery']['reused_step_ids'], ['a', 'b', 'c'])
+            self.assertFalse(detail['recovery']['requires_confirmation'])
+            response = fixture.retry(plan['run_id'], confirm_external_effects=False)
+            self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+            fixture.model.answer_error = None
+            fixture.run_attempt(response.get_json()['run']['plan'])
+            self.assertEqual(fixture.calls, ['a', 'b', 'c'])
+
+    def test_total_deadline_does_not_invoke_another_model_to_report_failure(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            clock = [0.0]
+            fixture.settings['chat_orchestration_total_timeout_seconds'] = 2
+            fixture.settings['chat_orchestration_step_timeout_seconds'] = 10
+            fixture.before_adapter = lambda *_args: clock.__setitem__(0, 5.0)
+            model_calls = len(fixture.model.calls)
+            with patch.dict(fixture.route.execute_plan.__globals__, {'time': SimpleNamespace(monotonic=lambda: clock[0])}):
+                events = frames(fixture.run_attempt(plan))
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['failure']['code'], 'run_timeout')
+            self.assertEqual(done['status'], 'failed')
+            self.assertEqual(len(fixture.model.calls), model_calls)
+            self.assertTrue(done['full_content'])
+
+    def test_failed_attempt_is_saved_and_retry_reuses_a_without_new_user_message(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            events = frames(fixture.run_attempt(plan))
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'failed')
+            self.assertEqual(done['outcome'], 'partial')
+            self.assertEqual(done['failure']['code'], 'step_timeout')
+            self.assertTrue(done['message_saved'])
+            self.assertEqual(fixture.calls, ['a', 'b'])
+            original = fixture.detail(plan['run_id'])
+            initial_steps = fixture.client.get(
+                f"/api/v2/orchestration/runs/{plan['run_id']}/steps?conversation_id=conv1"
+            ).get_json()['steps']
+            self.assertEqual(
+                {step['step_id']: step['status'] for step in initial_steps},
+                {'a': 'completed', 'b': 'failed', 'c': 'skipped', 'answer': 'completed'},
+            )
+            self.assertTrue(original['recovery']['eligible'])
+            self.assertTrue(original['recovery']['requires_confirmation'])
+            denied = fixture.retry(plan['run_id'], confirm_external_effects=False)
+            self.assertEqual(denied.status_code, 409, denied.get_data(as_text=True))
+            self.assertEqual(denied.get_json()['code'], 'confirmation_required')
+            response = fixture.retry(plan['run_id'])
+            self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+            child = response.get_json()['run']
+            self.assertEqual(child['attempt_index'], 2)
+            self.assertEqual(child['approval']['mode'], 'manual')
+            self.assertEqual(child['turn_id'], original['turn_id'])
+            self.assertEqual(fixture.calls, ['a', 'b'])
+            fixture.fail_b = False
+            events2 = frames(fixture.run_attempt(child['plan']))
+            done2 = next(event for event in events2 if event.get('type') == 'orchestration_done')
+            self.assertEqual(done2['status'], 'completed', events2)
+            self.assertEqual(fixture.calls, ['a', 'b', 'b', 'c'])
+            self.assertTrue(any(event.get('reused') for event in events2))
+            restored_steps = fixture.client.get(
+                f"/api/v2/orchestration/runs/{child['run_id']}/steps?conversation_id=conv1"
+            ).get_json()['steps']
+            self.assertEqual([step['step_id'] for step in restored_steps], ['a', 'b', 'c', 'answer'])
+            self.assertTrue(all(step['status'] == 'completed' for step in restored_steps))
+            self.assertTrue(restored_steps[0]['reused'])
+            self.assertTrue(restored_steps[0]['checkpoint_available'])
+            self.assertEqual(restored_steps[0]['reused_from_run_id'], plan['run_id'])
+            self.assertNotIn('checkpoint_chunk', json.dumps(restored_steps))
+            self.assertNotIn('input_fingerprint', json.dumps(restored_steps))
+            user_messages = [row for row in fixture.messages.items.values() if row.get('id', '').startswith('user_turn_')]
+            self.assertLessEqual(len(user_messages), 1)
+            self.assertIn('Saved findings a', json.dumps(fixture.model.calls[-1]))
+
+    def test_errors_never_leak_and_synthesis_failure_has_model_independent_reply(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.model.answer_error = RuntimeError('OTHER_SECRET_SENTINEL https://provider.internal/error')
+            events = frames(fixture.run_attempt(plan))
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            detail = fixture.detail(plan['run_id'])
+            steps = fixture.client.get(f"/api/v2/orchestration/runs/{plan['run_id']}/steps?conversation_id=conv1").get_json()
+            visible = json.dumps([events, detail, steps, list(fixture.messages.items.values()), fixture.model.calls])
+            self.assertNotIn('SECRET_SENTINEL', visible)
+            self.assertEqual(done['failure']['code'], 'step_timeout')
+            self.assertIn('model_failed', [failure['code'] for failure in done['failures']])
+            self.assertTrue(done['full_content'])
+            self.assertTrue(done['message_saved'])
+            self.assertNotIn('checkpoint_chunk', json.dumps(steps))
+            self.assertNotIn('input_fingerprint', json.dumps(steps))
+
+    def test_retry_is_idempotent_and_old_attempt_cannot_branch(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            first = fixture.retry(plan['run_id'])
+            self.assertEqual(first.status_code, 200, first.get_data(as_text=True))
+            again = fixture.retry(plan['run_id'])
+            self.assertEqual(again.status_code, 200, again.get_data(as_text=True))
+            self.assertEqual(first.get_json()['run']['run_id'], again.get_json()['run']['run_id'])
+            competing = fixture.retry(plan['run_id'], submission_id='another-tab')
+            self.assertEqual(competing.status_code, 409)
+            self.assertEqual(competing.get_json()['code'], 'recovery_changed')
+            self.assertEqual(len([row for row in fixture.runs.items.values() if row.get('retry_of_run_id')]), 1)
+            self.assertEqual(fixture.calls, ['a', 'b'])
+
+    def test_third_attempt_restores_second_attempt_successes_and_regenerates_answer(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            child = fixture.retry(plan['run_id']).get_json()['run']
+            fixture.fail_b = False
+            fixture.model.answer_error = RuntimeError('private synthesizer failure')
+            fixture.run_attempt(child['plan'])
+            second = fixture.detail(child['run_id'])
+            self.assertEqual(second['recovery']['reused_step_ids'], ['a', 'b', 'c'])
+            third_response = fixture.retry(child['run_id'], submission_id='third')
+            self.assertEqual(third_response.status_code, 200, third_response.get_data(as_text=True))
+            fixture.model.answer_error = None
+            third = third_response.get_json()['run']
+            events = frames(fixture.run_attempt(third['plan']))
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'completed', events)
+            self.assertEqual(fixture.calls, ['a', 'b', 'b', 'c'])
+            self.assertEqual(len([event for event in events if event.get('reused')]), 3)
+            self.assertNotIn('superseded_by_run_id', fixture.runs.read_item(child['run_id'], 'conv1'))
+            self.assertEqual(fixture.detail(plan['run_id'])['recovery']['current_run_id'], third['run_id'])
+
+    def test_two_tabs_racing_publish_only_one_successor(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            competitor = []
+            fixture.runs.before_batch = lambda: competitor.append(fixture.retry(plan['run_id'], submission_id='tab-two'))
+            response = fixture.retry(plan['run_id'], submission_id='tab-one')
+            self.assertEqual(competitor[0].status_code, 200, competitor[0].get_data(as_text=True))
+            self.assertEqual(response.status_code, 409)
+            self.assertEqual(len([row for row in fixture.runs.items.values() if row.get('retry_of_run_id')]), 1)
+
+    def test_expired_worker_cannot_publish_after_retry_claim(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            recovery = fixture.route.prepare_retry.__globals__
+            prepared = []
+            def expire_and_retry(step, context, kwargs):
+                if step['step_id'] != 'b':
+                    return
+                fixture.runs.items[('conv1', plan['run_id'])]['execution_lease']['expires_at'] = (
+                    recovery['_now']() - timedelta(seconds=2)
+                ).isoformat()
+                prepared.append(fixture.retry(plan['run_id']))
+            fixture.before_adapter = expire_and_retry
+            events = frames(fixture.run_attempt(plan))
+            self.assertEqual(prepared[0].status_code, 200, prepared[0].get_data(as_text=True))
+            self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events))
+            self.assertTrue(any(event.get('error') for event in events))
+            self.assertFalse(any(
+                (row.get('metadata') or {}).get('orchestration', {}).get('run_id') == plan['run_id']
+                for row in fixture.messages.items.values()
+            ))
+
+    def test_heartbeat_runs_during_blocked_adapter_and_preserves_concurrent_stop(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            recovery = fixture.route.prepare_retry.__globals__
+            observed = []
+            def block_and_stop(step, context, kwargs):
+                if step['step_id'] != 'a':
+                    return
+                before = fixture.runs.read_item(plan['run_id'], 'conv1')['execution_lease']['heartbeat_at']
+                threading.Event().wait(0.06)
+                current = fixture.runs.read_item(plan['run_id'], 'conv1')
+                observed.append(current['execution_lease']['heartbeat_at'] != before)
+                lease = fixture.route.ExecutionLease(current, lambda: True)
+                fixture.runs.before_replace = lambda: recovery['request_cancellation'](
+                    plan['run_id'], 'user1', 'conv1', lambda: True,
+                )
+                lease.renew()
+                observed.append(lease.cancel_requested())
+            fixture.before_adapter = block_and_stop
+            with patch.dict(recovery, {'HEARTBEAT_SECONDS': 0.01}):
+                events = frames(fixture.run_attempt(plan))
+            self.assertEqual(observed, [True, True])
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'cancelled')
+
+    def test_stream_disconnect_does_not_cancel_or_lose_terminal_persistence(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            release = threading.Event()
+            fixture.before_adapter = lambda step, *_args: release.wait(2) if step['step_id'] == 'a' else None
+            response = fixture.client.post('/api/v2/orchestration/run', json={
+                'conversation_id': 'conv1', 'run_id': plan['run_id'],
+            }, buffered=False)
+            response.close()
+            release.set()
+            for _ in range(100):
+                record = fixture.runs.read_item(plan['run_id'], 'conv1')
+                if record.get('assistant_message_id') and not record.get('execution_lease'):
+                    break
+                threading.Event().wait(0.02)
+            self.assertTrue(record.get('assistant_message_id'))
+            self.assertNotEqual(record['status'], 'cancelled')
+            self.assertFalse(record.get('cancellation_requested_at'))
+
+    def test_message_publication_batch_rejects_a_worker_fenced_after_its_last_read(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            recovery = fixture.route.prepare_retry.__globals__
+            children = []
+            def fence_before_publish():
+                fixture.runs.items[('conv1', plan['run_id'])]['execution_lease']['expires_at'] = (
+                    recovery['_now']() - timedelta(seconds=1)
+                ).isoformat()
+                children.append(fixture.retry(plan['run_id']))
+            fixture.messages.before_batch = fence_before_publish
+            events = frames(fixture.run_attempt(plan))
+            self.assertEqual(children[0].status_code, 200, children[0].get_data(as_text=True))
+            self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events))
+            self.assertFalse(any(
+                (row.get('metadata') or {}).get('orchestration', {}).get('run_id') == plan['run_id']
+                for row in fixture.messages.items.values()
+            ))
+
+    def test_revoked_agent_or_model_blocks_preparation_without_replaying_success(self):
+        for boundary in ('agent', 'model'):
+            with self.subTest(boundary=boundary), RecoveryFixture() as fixture:
+                plan = fixture.plan_attempt()
+                fixture.run_attempt(plan)
+                patcher = (
+                    patch.object(fixture.route, 'resolve_agent_catalog', return_value=[])
+                    if boundary == 'agent' else
+                    patch.object(fixture.route, 'resolve_orchestration_model', side_effect=PermissionError('private detail'))
+                )
+                with patcher:
+                    response = fixture.retry(plan['run_id'])
+                self.assertEqual(response.status_code, 409, response.get_data(as_text=True))
+                self.assertEqual(response.get_json()['code'], 'recovery_unavailable')
+                self.assertEqual(fixture.calls, ['a', 'b'])
+
+    def test_deletion_removes_chunks_and_fences_late_checkpoint_and_message_writes(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            recovery = fixture.route.prepare_retry.__globals__
+            record = fixture.runs.read_item(plan['run_id'], 'conv1')
+            store = recovery['checkpoint_store'](record, lambda: True, token='late-worker')
+            recovery['cleanup_conversation_checkpoints'](
+                'conv1', 'user1', lambda: True, message_container=fixture.messages,
+                conversation_container=fixture.conversations,
+            )
+            self.assertFalse(any(
+                row.get('record_type') in ('checkpoint_chunk', 'checkpoint_manifest')
+                for row in fixture.steps.items.values()
+            ))
+            with self.assertRaises(recovery['CheckpointError']):
+                store.initialize()
+            self.assertEqual(fixture.client.get(
+                f"/api/v2/orchestration/runs/{plan['run_id']}?conversation_id=conv1"
+            ).status_code, 404)
+
+    def test_legacy_absent_checkpoints_are_readable_but_never_replayed(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            record = fixture.runs.items[('conv1', plan['run_id'])]
+            record.update({'status': 'failed', 'started_at': '2020-01-01T00:00:00Z', 'error': 'PRIVATE_LEGACY_ERROR'})
+            detail = fixture.detail(plan['run_id'])
+            self.assertEqual(detail['recovery']['reason_code'], 'legacy_no_checkpoints')
+            self.assertNotIn('PRIVATE_LEGACY_ERROR', json.dumps(detail))
+            self.assertEqual(fixture.calls, [])
+
+    def test_corrupt_chunk_context_change_and_revoked_owner_block_without_replay(self):
+        for scenario in ('corrupt', 'context', 'owner'):
+            with self.subTest(scenario=scenario), RecoveryFixture() as fixture:
+                plan = fixture.plan_attempt()
+                fixture.run_attempt(plan)
+                if scenario == 'corrupt':
+                    row = next(row for row in fixture.steps.items.values() if row.get('record_type') == 'checkpoint_chunk')
+                    row['data'] = 'corrupt'
+                elif scenario == 'context':
+                    fixture.messages.items[('conv1', 'u1')]['content'] = 'Changed prior context'
+                else:
+                    fixture.conversations.items[('conv1', 'conv1')]['user_id'] = 'other-user'
+                record = fixture.runs.read_item(plan['run_id'], 'conv1')
+                response = fixture.client.post(f"/api/v2/orchestration/runs/{plan['run_id']}/retry", json={
+                    'conversation_id': 'conv1', 'submission_id': 'retry',
+                    'expected_version': record['recovery_version'], 'confirm_external_effects': True,
+                })
+                self.assertIn(response.status_code, (404, 409), response.get_data(as_text=True))
+                self.assertEqual(fixture.calls, ['a', 'b'])
+
+    def test_lost_publication_response_returns_the_committed_attempt(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.run_attempt(plan)
+            def lose_response():
+                raise AzureError('private lost reply')
+            fixture.runs.after_batch = lose_response
+            response = fixture.retry(plan['run_id'])
+            self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+            self.assertEqual(response.get_json()['run']['attempt_index'], 2)
+
+    def test_explicit_stop_is_not_a_timeout(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            def stop(step, context, kwargs):
+                if step['step_id'] == 'b':
+                    response = fixture.client.post(f"/api/v2/orchestration/cancel/{plan['run_id']}", json={'conversation_id': 'conv1'})
+                    self.assertEqual(response.status_code, 200)
+            fixture.before_adapter = stop
+            done = next(event for event in frames(fixture.run_attempt(plan)) if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'cancelled')
+            self.assertEqual(done['failure']['code'], 'user_cancelled')
+            self.assertTrue(done['message_saved'])
+
+    def test_checkpoint_failure_before_effects_prevents_adapter_execution(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.steps.fail_writes = True
+            events = frames(fixture.run_attempt(plan))
+            self.assertEqual(fixture.calls, [])
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertEqual(done['status'], 'failed')
+            self.assertFalse(done['recovery']['eligible'])
+
+    def test_unavailable_message_store_reports_not_saved(self):
+        with RecoveryFixture() as fixture:
+            plan = fixture.plan_attempt()
+            fixture.before_adapter = lambda *_args: setattr(fixture.messages, 'fail_writes', True)
+            events = frames(fixture.run_attempt(plan))
+            done = next(event for event in events if event.get('type') == 'orchestration_done')
+            self.assertFalse(done['message_saved'])
+            self.assertIsNone(done['message_id'])
+            self.assertTrue(any(event.get('error') for event in events))
+
+
+class CheckpointCodecTests(unittest.TestCase):
+    def test_structured_engine_failure_wins_over_an_explanatory_reply(self):
+        with RecoveryFixture() as fixture:
+            classify = fixture.modules.adapters._tabular_evidence_status
+            self.assertEqual(classify('failed', 'The service did not finish.', []), 'failed')
+            self.assertEqual(classify('foreground', 'The source mentions errors and cancellation.', []), 'completed')
+            failed_analysis = {
+                'reply': 'SECRET_PROVIDER_BODY',
+                'coverage': {'documents': [{
+                    'document_id': 'd', 'total_windows': 2, 'processed_windows': 1, 'failed_windows': 1,
+                }]},
+            }
+            engine = SimpleNamespace(run_document_analysis=lambda *args, **kwargs: failed_analysis)
+            with patch.dict('sys.modules', {'functions_document_analysis': engine}):
+                result = fixture.modules.adapters.run_document_analyze(
+                    {'arguments': {'document_ids': ['d'], 'analysis_prompt': 'Read the document'}},
+                    {'invoke_prompt': lambda *_args, **_kwargs: None}, settings={}, user_id='user1',
+                    emit=lambda _event: None, cancel_requested=lambda: False,
+                )
+            self.assertEqual(result['status'], 'failed')
+            self.assertNotIn('SECRET_PROVIDER_BODY', json.dumps(result))
+
+    def test_exception_types_and_structured_http_status_never_parse_error_prose(self):
+        with RecoveryFixture() as fixture:
+            normalize = fixture.route.execute_plan.__globals__['failure_from_exception']
+            self.assertEqual(normalize(TimeoutError('cancelled by user'))['code'], 'provider_timeout')
+            self.assertEqual(normalize(ConnectionError('SECRET'))['code'], 'connection_failed')
+            http_error = RuntimeError('SECRET https://private')
+            http_error.status_code = 504
+            failure = normalize(http_error)
+            self.assertEqual(failure['code'], 'provider_http_error')
+            self.assertEqual(failure['provider_status'], 504)
+            self.assertNotIn('SECRET', json.dumps(failure))
+
+    def test_source_versions_revocation_and_expired_artifacts_block_reuse(self):
+        with RecoveryFixture() as fixture:
+            namespace = fixture.route.prepare_retry.__globals__
+            validate = namespace['_validate_payload_sources']
+            error = namespace['CheckpointError']
+            context = fixture.route.RunContext(user_id='user1', conversation_id='conv1')
+            current = {
+                'document_id': 'doc', 'authorization_status': 'authorized',
+                'source_version': 'v1', 'source_revision': 'etag1', 'scope': 'personal', 'scope_id': 'user1',
+            }
+            context.resolve_source_manifest = lambda ids: [deepcopy(current)]
+            payload = {'state': {'documents_touched': ['doc'], 'execution_manifest': [deepcopy(current)]}}
+            validate(payload, context, {}, 'user1')
+            for key, value in (
+                ('authorization_status', 'denied'), ('source_version', 'v2'),
+                ('source_revision', 'etag2'), ('scope_id', 'another-user'),
+            ):
+                original = current[key]
+                current[key] = value
+                with self.assertRaises(error):
+                    validate(payload, context, {}, 'user1')
+                current[key] = original
+            payload['state']['artifacts'] = [{'artifact_message_id': 'expired'}]
+            context.validate_checkpoint_artifacts = lambda artifacts: False
+            with self.assertRaises(error):
+                validate(payload, context, {}, 'user1')
+
+    def test_json_byte_bounds_immutability_integrity_and_authorization(self):
+        with RecoveryFixture() as fixture:
+            recovery = fixture.route.prepare_retry.__globals__
+            checkpoint_type = recovery['CheckpointStore']
+            error_type = recovery['CheckpointError']
+            namespace = checkpoint_type.commit.__globals__
+            authorized = [True]
+            store = checkpoint_type(
+                fixture.steps, run_id='codec-run', user_id='user1', conversation_id='conv1',
+                turn_id='codec-turn', token='codec-token', authorize=lambda: authorized[0],
+            )
+            store.initialize()
+            context = fixture.route.RunContext(run_id='codec-run', user_id='user1', conversation_id='conv1')
+            context.notes = ['漢字🙂' * 70000]
+            step = {'step_id': 'a'}
+            result = fixture.route.execute_plan.__globals__['build_step_result'](notes=context.notes)
+            payload = store.commit(step, result, context, input_fingerprint='input', binding='binding')
+            self.assertEqual(store.load('a'), payload)
+            self.assertGreater(len([row for row in fixture.steps.items.values() if row.get('record_type') == 'checkpoint_chunk']), 1)
+            self.assertTrue(all(len(namespace['json_bytes'](row)) < namespace['MAX_DOCUMENT_BYTES'] for row in fixture.steps.items.values()))
+            with self.assertRaises(error_type), patch.dict(namespace, {'MAX_CHECKPOINT_BYTES': 100}):
+                store.commit({'step_id': 'large'}, result, context, input_fingerprint='input', binding='binding')
+            with self.assertRaises(error_type):
+                store.commit(step, {**result, 'message': 'different'}, context, input_fingerprint='input', binding='binding')
+            bad = next(row for row in fixture.steps.items.values() if row.get('record_type') == 'checkpoint_chunk')
+            bad['data'] = 'broken'
+            with self.assertRaises(error_type):
+                store.load('a')
+            authorized[0] = False
+            with self.assertRaises(error_type):
+                store.load('a')
+            for value in (float('nan'), object(), {1: 'non-string key'}):
+                with self.assertRaises(error_type):
+                    namespace['json_bytes'](value)
+
+    def test_effective_inputs_include_undeclared_earlier_findings(self):
+        with RecoveryFixture() as fixture:
+            namespace = fixture.route.prepare_retry.__globals__
+            context = fixture.route.RunContext(run_id='r', user_id='user1', conversation_id='conv1')
+            step = {'step_id': 'action', 'capability_id': 'action_invoke', 'arguments': {}, 'depends_on': []}
+            before = namespace['step_input_fingerprint'](step, context, 'binding')
+            context.notes.append('An earlier step found different input')
+            self.assertNotEqual(before, namespace['step_input_fingerprint'](step, context, 'binding'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_orchestration_citation_persistence.py
+++ b/functional_tests/test_orchestration_citation_persistence.py
@@ -1,7 +1,7 @@
 # test_orchestration_citation_persistence.py
 """
 Functional test for orchestration citation persistence.
-Version: 0.261.098
+Version: 0.261.105
 Implemented in: 0.261.087
 
 Action tool-citation channel coverage added in: 0.261.098
@@ -157,7 +157,7 @@ def test_cited_documents_reach_the_conversation():
             'the conversation used-document list is what the drawer reads, and '
             'merge_cited_documents_into_conversation is what extends it'
         )
-        assert 'upsert_item' in body, 'the merged conversation has to be written back'
+        assert 'replace_item' in body and 'IfNotModified' in body, 'cited sources must be saved without overwriting a concurrent deletion fence'
         assert 'user_id' in body, (
             'ownership must be checked before writing to a conversation'
         )

--- a/functional_tests/test_orchestration_conversation_context_routes.py
+++ b/functional_tests/test_orchestration_conversation_context_routes.py
@@ -1,7 +1,7 @@
 # test_orchestration_conversation_context_routes.py
 """
 Functional tests for conversation context across real orchestration HTTP/SSE routes.
-Version: 0.261.104
+Version: 0.261.105
 Implemented in: 0.261.096
 Prompt attachment integration: 0.261.097
 Direct action integration: 0.261.098
@@ -531,12 +531,14 @@ class ConversationRouteTests(unittest.TestCase):
                 self.model.answer_response = response
                 plan = self.planned()
                 events = frames(self.run_plan(plan))
-                self.assertTrue(any(event.get('error') for event in events), events)
-                self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events))
+                terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+                self.assertEqual(terminal['status'], 'failed')
+                self.assertTrue(terminal['message_saved'])
+                self.assertTrue(terminal['full_content'])
                 self.assertNotIn('PRIVATE_PROVIDER_RESPONSE', json.dumps(events))
                 stored = self.runs.read_item(plan['run_id'], 'conv1')
                 self.assertEqual(stored['status'], 'failed')
-                self.assertFalse(stored.get('assistant_message_id'))
+                self.assertTrue(stored.get('assistant_message_id'))
                 self.assertEqual(stored['token_usage']['total_tokens'], 45)
         for client in self.model_clients:
             client.close.assert_called_once_with()
@@ -551,7 +553,9 @@ class ConversationRouteTests(unittest.TestCase):
         plan = self.planned()
         with patch.object(self.route, 'log_event') as log:
             events = frames(self.run_plan(plan))
-        self.assertTrue(any(event.get('error') for event in events))
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['status'], 'failed')
+        self.assertEqual(terminal['failure']['provider_status'], 400)
         self.assertNotIn('PRIVATE_PROVIDER_RESPONSE', json.dumps(events))
         self.assertNotIn('PRIVATE_PROVIDER_RESPONSE', repr(log.call_args_list))
         self.assertEqual(self.runs.read_item(plan['run_id'], 'conv1')['status'], 'failed')
@@ -644,7 +648,7 @@ class ConversationRouteTests(unittest.TestCase):
         self.assertEqual(second_run['request_resolution']['clarification'], '')
         self.assertFalse(any(event.get('error') for event in frames(self.run_plan(second))))
         self.assertEqual(self.runs.read_item(second['run_id'], 'conv1')['status'], 'completed')
-        self.assertEqual(len(self.messages.items), 4)
+        self.assertEqual(len([row for row in self.messages.items.values() if row.get('role') in ('user', 'assistant')]), 4)
         resolution_calls = [
             call for call in self.model.calls
             if call['messages'][0]['content'] == self.modules.planner.RESOLUTION_SYSTEM_PROMPT
@@ -839,7 +843,8 @@ class ConversationRouteTests(unittest.TestCase):
             metadata={'masked': True}
         )
         events = frames(self.run_plan(plan))
-        self.assertTrue(any('context changed' in event.get('error', '').lower() for event in events))
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
         self.assertEqual(len(self.model.calls), 2)
         self.assertEqual(self.runs.read_item(plan['run_id'], 'conv1')['status'], 'failed')
 
@@ -1078,7 +1083,8 @@ class ConversationRouteTests(unittest.TestCase):
             metadata={'masked': True}
         )
         events = frames(self.run_plan(plan))
-        self.assertTrue(any('context changed' in event.get('error', '').lower() for event in events))
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
         self.assertEqual(len(self.model.calls), 2)
         self.assertEqual(self.runs.read_item(plan['run_id'], 'conv1')['status'], 'failed')
 

--- a/functional_tests/test_orchestration_executor.py
+++ b/functional_tests/test_orchestration_executor.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+# test_orchestration_executor.py
 """
 Functional test for the chat orchestration step executor.
-Version: 0.261.085
+Version: 0.261.105
 Implemented in: 0.261.085
 
 The executor is what turns a validated plan into an answer. Its job is almost entirely
@@ -198,7 +198,7 @@ def test_cancellation_stops_the_run():
             assert order == [], f"Steps ran after cancellation: {order}"
             assert result['status'] == schema.PLAN_STATUS_CANCELLED
 
-            # Cancelled by an adapter mid-run.
+            # An adapter interruption without an explicit Stop is not user cancellation.
             order2 = []
             plan2 = _plan([
                 _step('a', 'document_search'),
@@ -211,9 +211,9 @@ def test_cancellation_stops_the_run():
                 plan2, context2, settings=SETTINGS, user_id='user_1',
                 get_adapter=_recording_adapters(schema, order2, cancel_on='a'),
             )
-            assert result2['status'] == schema.PLAN_STATUS_CANCELLED, (
-                "An adapter reporting cancellation must cancel the run"
-            )
+            assert result2['status'] == schema.PLAN_STATUS_FAILED
+            assert result2['failure']['code'] == 'execution_interrupted'
+            assert 'answer' in order2
 
         print("Test passed!")
         return True
@@ -249,7 +249,8 @@ def test_budgets_are_enforced():
             assert 'answer' in order, (
                 "The budget must not consume the step that produces the answer"
             )
-            assert result['message'] == 'ANSWER'
+            assert result['message'].startswith('ANSWER')
+            assert result['outcome'] == 'partial'
 
             # Replan hints are collected but bounded, and the executor never re-plans
             # itself -- the route owns that loop.
@@ -387,7 +388,7 @@ def test_unknown_capability_fails_the_step_not_the_run():
 
             statuses = {record['step_id']: record['status'] for record in result['steps']}
             assert statuses['ghost'] == schema.STEP_STATUS_FAILED
-            assert result['message'] == 'ANSWER', (
+            assert result['message'].startswith('ANSWER'), (
                 "One unrunnable step must not stop the user getting an answer"
             )
 

--- a/functional_tests/test_orchestration_memory_context.py
+++ b/functional_tests/test_orchestration_memory_context.py
@@ -1,7 +1,7 @@
 # test_orchestration_memory_context.py
 """Functional regressions for audience-bound orchestration memory.
 
-Version: 0.261.104
+Version: 0.261.105
 Implemented in: 0.261.104
 
 Uses real Flask routes, revisions, executor, adapters and the shared memory reader.
@@ -151,7 +151,9 @@ class OrchestrationMemoryTests(unittest.TestCase):
         plan = self.group_plan()
         self.after_search = lambda: setattr(self.membership, 'side_effect', PermissionError('revoked'))
         events = context_tests.frames(self.run_plan(plan))
-        self.assertTrue(any(event.get('error') for event in events), events)
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
+        self.assertFalse(terminal['recovery']['eligible'])
         self.assertEqual(self.answer_calls(), [])
 
     def test_disabling_memory_during_retrieval_removes_final_context_and_citations(self):
@@ -175,7 +177,9 @@ class OrchestrationMemoryTests(unittest.TestCase):
         plan = self.planned()
         self.after_search = self.shared_source
         events = context_tests.frames(self.run_plan(plan))
-        self.assertTrue(any(event.get('error') for event in events), events)
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
+        self.assertFalse(terminal['recovery']['eligible'])
         self.assertEqual(self.answer_calls(), [])
 
     def test_changing_audience_during_planning_prevents_publication(self):
@@ -200,9 +204,10 @@ class OrchestrationMemoryTests(unittest.TestCase):
 
         self.model.chat.completions.create = change_during_answer
         events = context_tests.frames(self.run_plan(plan))
-        self.assertTrue(any(event.get('error') for event in events), events)
-        self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events), events)
-        self.assertFalse(self.runs.read_item(plan['run_id'], 'conv1').get('assistant_message_id'))
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
+        self.assertTrue(terminal['message_saved'])
+        self.assertNotIn('Saved destination:', json.dumps(events))
 
     def test_revoked_group_membership_during_synthesis_blocks_answer_and_citations(self):
         plan = self.group_plan()
@@ -216,12 +221,13 @@ class OrchestrationMemoryTests(unittest.TestCase):
 
         self.model.chat.completions.create = revoke_during_answer
         events = context_tests.frames(self.run_plan(plan))
-        self.assertTrue(any(event.get('error') for event in events), events)
-        self.assertFalse(any(event.get('type') == 'orchestration_done' for event in events), events)
+        terminal = next(event for event in events if event.get('type') == 'orchestration_done')
+        self.assertEqual(terminal['failure']['code'], 'context_unavailable')
+        self.assertTrue(terminal['message_saved'])
         self.assertNotIn('GROUP MEMORY', json.dumps(events))
         stored = self.runs.read_item(plan['run_id'], 'conv1')
         self.assertEqual(stored['status'], 'failed')
-        self.assertFalse(stored.get('assistant_message_id'))
+        self.assertTrue(stored.get('assistant_message_id'))
 
     def private_memory_question(self):
         question = revision_tests.question()

--- a/functional_tests/test_orchestration_run_hydration_routes.py
+++ b/functional_tests/test_orchestration_run_hydration_routes.py
@@ -1,7 +1,7 @@
 # test_orchestration_run_hydration_routes.py
 """
 Functional test for the orchestration run hydration endpoints and their projections.
-Version: 0.261.104
+Version: 0.261.105
 Implemented in: 0.261.099
 
 Orchestration runs have always been persisted, but nothing in the browser read them back, so a
@@ -29,6 +29,8 @@ sys.path.append(str(Path(__file__).resolve().parent))
 
 from test_support.versioning import assert_app_version_at_least  # noqa: E402
 from test_support.orchestration_research import _definitions  # noqa: E402
+from test_support.app_stubs import stubbed_config  # noqa: E402
+from test_support.orchestration_revisions import AtomicMemoryContainer  # noqa: E402
 
 
 IMPLEMENTED_IN = "0.261.099"
@@ -94,10 +96,18 @@ def _load_projections():
         raise AssertionError(f"missing helpers in the route module: {sorted(missing)}")
     registry = _definitions("functions_orchestration_registry.py")
     events = _definitions("functions_orchestration_events.py")
+    with stubbed_config(
+        cosmos_orchestration_runs_container=AtomicMemoryContainer('conversation_id'),
+        cosmos_orchestration_run_steps_container=AtomicMemoryContainer('run_id'),
+    ):
+        from functions_orchestration_recovery import public_execution_fields
+        from functions_orchestration_schema import safe_failure
     namespace = {
         "deepcopy": deepcopy,
         "required_capability_ids": registry["required_capability_ids"],
         "merge_reasoning_adjustments": events["merge_reasoning_adjustments"],
+        "public_execution_fields": public_execution_fields,
+        "safe_failure": safe_failure,
     }
     exec(compile(ast.Module(body=picked, type_ignores=[]), str(ROUTE_FILE), "exec"), namespace)
     return namespace
@@ -140,6 +150,7 @@ def test_summary_projection_is_an_allowlist():
             "artifact_count",
             "revision",
             "approval",
+            "attempt_index", "retry_of_run_id", "failure", "failures", "recovery",
         }
         assert set(row) == expected_keys, (
             f"unexpected listing shape: extra={sorted(set(row) - expected_keys)} "

--- a/functional_tests/test_support/orchestration_recovery.py
+++ b/functional_tests/test_support/orchestration_recovery.py
@@ -1,0 +1,108 @@
+# orchestration_recovery.py
+"""Offline browser-to-Flask recovery fixture using real routes and checkpoints.
+
+Version: 0.261.105
+Implemented in: 0.261.105
+Use ``with RecoveryFixture() as fixture``. ``plan_attempt()``, ``run_attempt(plan)``,
+``detail(run_id)`` and ``retry(run_id, **overrides)`` operate through the Flask client.
+``calls`` records gather adapter invocations; ``fail_b`` controls the failed step.
+"""
+
+import unittest
+from copy import deepcopy
+from unittest.mock import patch
+
+# Keep NumPy's native runtime outside per-test sys.modules snapshots. Reloading
+# Semantic Kernel otherwise registers hundreds of DLL search paths on Windows.
+import numpy
+
+import test_orchestration_conversation_context_routes as context_routes
+
+
+frames = context_routes.frames
+
+
+class RecoveryFixture(unittest.TestCase):
+    __test__ = False
+    plan = context_routes.ConversationRouteTests.plan
+    planned = context_routes.ConversationRouteTests.planned
+
+    def setUp(self):
+        context_routes.ConversationRouteTests.setUp(self)
+        self.calls = []
+        self.fail_b = True
+        self.before_adapter = None
+        self.settings['enable_semantic_kernel'] = True
+        agent = {'id': 'agent1', 'name': 'RecoveryAgent', 'display_name': 'Recovery agent'}
+        patcher = patch.object(self.route, 'resolve_agent_catalog', lambda *args, **kwargs: [deepcopy(agent)])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.model.plan_override = {
+            'kind': 'plan', 'intent': {'summary': 'Gather two results.', 'complexity': 'simple'},
+            'steps': [
+                {'step_id': 'a', 'capability_id': 'document_search', 'title': 'Gather A', 'arguments': {'query': 'A'}},
+                {'step_id': 'b', 'capability_id': 'agent_invoke', 'title': 'Gather B',
+                 'arguments': {'agent_name': 'RecoveryAgent', 'task': 'B'}, 'depends_on': ['a']},
+                {'step_id': 'c', 'capability_id': 'document_search', 'title': 'Gather C',
+                 'arguments': {'query': 'C'}, 'depends_on': ['b']},
+                {'step_id': 'answer', 'capability_id': 'respond', 'title': 'Answer', 'arguments': {}, 'depends_on': ['c']},
+            ],
+        }
+        namespace = self.route.execute_plan.__globals__
+        build_step_result = namespace['build_step_result']
+        original = namespace['_default_get_adapter']
+
+        def get_adapter(capability):
+            if capability == 'respond':
+                return original(capability)
+
+            def adapter(step, context, **kwargs):
+                self.calls.append(step['step_id'])
+                if self.before_adapter:
+                    self.before_adapter(step, context, kwargs)
+                if step['step_id'] == 'b' and self.fail_b:
+                    return build_step_result(
+                        status='failed', failure=namespace['build_failure']('step_timeout'),
+                        error='SECRET_SENTINEL https://private.test/<script>private</script>',
+                        summary='SECRET_SENTINEL',
+                    )
+                return build_step_result(notes=[f"Saved findings {step['step_id']}"], summary='Completed')
+
+            return adapter
+
+        patcher = patch.dict(namespace, {'_default_get_adapter': get_adapter})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def __enter__(self):
+        try:
+            self.setUp()
+        except Exception:
+            self.doCleanups()
+            raise
+        return self
+
+    def __exit__(self, *_args):
+        self.doCleanups()
+
+    def plan_attempt(self):
+        return self.planned()
+
+    def run_attempt(self, plan):
+        return self.client.post('/api/v2/orchestration/run', json={
+            'conversation_id': 'conv1', 'run_id': plan['run_id'],
+            **({'expected_version': plan['edit_version']} if plan.get('edit_version') else {}),
+        }, buffered=True)
+
+    def detail(self, run_id):
+        response = self.client.get(f'/api/v2/orchestration/runs/{run_id}?conversation_id=conv1')
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        return response.get_json()['run']
+
+    def retry(self, run_id, **overrides):
+        body = {
+            'conversation_id': 'conv1', 'submission_id': 'retry-submission',
+            'expected_version': self.detail(run_id)['recovery']['expected_version'],
+            'confirm_external_effects': True, **overrides,
+        }
+        return self.client.post(f'/api/v2/orchestration/runs/{run_id}/retry', json=body)

--- a/functional_tests/test_support/orchestration_revisions.py
+++ b/functional_tests/test_support/orchestration_revisions.py
@@ -2,7 +2,7 @@
 """
 In-memory Cosmos boundary for conditional orchestration revision tests.
 
-Version: 0.261.102
+Version: 0.261.105
 Implemented in: 0.261.102
 
 Batch operations are formatted by the installed SDK and applied to a copy. A failed
@@ -160,8 +160,9 @@ class AtomicMemoryContainer:
                 deepcopy(item) for (partition, _), item in self.items.items()
                 if partition_key is None or partition == partition_key
             ]
+        run_field = 'run_id' if re.search(r'\bc\.run_id\s*=\s*@run_id\b', query, re.IGNORECASE) else 'id'
         for parameter, field in (
-            ('@conversation_id', 'conversation_id'), ('@user_id', 'user_id'), ('@run_id', 'id'),
+            ('@conversation_id', 'conversation_id'), ('@user_id', 'user_id'), ('@run_id', run_field),
         ):
             if parameter in params:
                 rows = [row for row in rows if row.get(field) == params[parameter]]
@@ -200,5 +201,7 @@ class AtomicMemoryContainer:
         for field in ('timestamp', 'created_at', 'turn_index', 'revision'):
             if f'ORDER BY c.{field} DESC' in query:
                 rows.sort(key=lambda row: row.get(field, 0 if field in ('revision', 'turn_index') else ''), reverse=True)
+        if 'ORDER BY c.step_index ASC' in query:
+            rows.sort(key=lambda row: row.get('step_index', 0))
         top = re.search(r'SELECT TOP (\d+)', query)
         return rows[:int(top.group(1))] if top else rows

--- a/ui_tests/fixtures/orchestration/harness_entry.tsx
+++ b/ui_tests/fixtures/orchestration/harness_entry.tsx
@@ -179,6 +179,8 @@ function reset(): void {
     roots.clear();
     orchestrationStore.useOrchestrationStore.setState({
         plans: {},
+        runRecovery: {},
+        recoveryTarget: null,
         elicitations: {},
         elicitationDrafts: {},
         edits: {},

--- a/ui_tests/test_v2_orchestration_recovery.py
+++ b/ui_tests/test_v2_orchestration_recovery.py
@@ -1,0 +1,596 @@
+# test_v2_orchestration_recovery.py
+"""
+Real-component browser coverage for orchestration failure and checkpoint recovery.
+Version: 0.261.105
+Implemented in: 0.261.105
+
+The production controller, SSE reader, stores, message list, and Run drawer execute
+in the existing local/Azure Playwright harness. Only API responses are deterministic.
+The companion backend test forwards those requests to the actual Flask routes.
+"""
+
+import copy
+import json
+from urllib.parse import urlsplit
+
+import pytest
+from playwright.sync_api import expect
+
+import test_v2_orchestration_plan_editor as editor_tests
+from test_v2_orchestration_plan_editor import (  # noqa: F401
+    connect_options,
+    editor_assets,
+    editor_browser,
+)
+
+
+pytestmark = pytest.mark.ui
+CONVERSATION = "recovery-chat"
+TURN = "recovery-turn"
+FAILURE = "The selected agent did not finish before this step's time limit."
+
+
+class RecoveryApi:
+    """Saved attempts plus explicit gates for stream loss and concurrent requests."""
+
+    def __init__(self, assets):
+        self.assets = assets
+        self.plan = editor_tests.make_plan(CONVERSATION, TURN)
+        self.plan["steps"][1].update(capability_id="agent", title="Ask the selected agent")
+        self.records = {}
+        self.steps = {}
+        self.messages = [{
+            "id": "user-original", "conversation_id": CONVERSATION, "role": "user",
+            "content": "Compare quarterly reports.", "metadata": {"orchestration_turn_id": TURN},
+        }]
+        self.requests = []
+        self.errors = []
+        self.preparations = {}
+        self.prepare_mode = "success"
+        self.stream_mode = "failure"
+        self.waiting = []
+        self.add_record(self.plan)
+
+    def add_record(self, plan, attempt=1, retry_of=None):
+        record = {
+            "run_id": plan["run_id"], "conversation_id": CONVERSATION, "turn_id": TURN,
+            "status": plan["status"], "plan": copy.deepcopy(plan), "turn_index": 0,
+            "created_at": f"2026-09-08T12:00:0{attempt}Z", "started_at": None, "completed_at": None,
+            "user_message_id": "user-original", "user_message": "Compare quarterly reports.",
+            "assistant_message_id": None, "attempt_index": attempt, "retry_of_run_id": retry_of,
+            "plan_summary": {
+                "plan_id": plan["plan_id"], "turn_id": TURN, "step_count": 3,
+                "intent_summary": plan["intent"]["summary"], "status": plan["status"],
+            }, "capabilities_used": [], "artifact_count": 0, "approval": plan["approval"], "revision": 0,
+        }
+        self.records[plan["run_id"]] = record
+        self.steps[plan["run_id"]] = []
+        return record
+
+    def recovery(self, run_id):
+        return {
+            "eligible": True, "reason_code": None, "message": "Completed steps were saved.",
+            "expected_version": "recovery-v1", "source_run_id": run_id,
+            "retry_step_ids": ["research", "answer"], "reused_step_ids": ["read"],
+            "requires_confirmation": True,
+        }
+
+    def finish(self, run_id, status="failed"):
+        record = self.records[run_id]
+        record.update(
+            status=status, outcome=status, completed_at="2026-09-08T12:01:00Z",
+            finalization_status="saved", message_saved=True,
+        )
+        record["plan"]["status"] = status
+        record["plan_summary"]["status"] = status
+        failure = {"code": "step_timeout", "message": FAILURE, "step_id": "research"}
+        record["failure"] = failure if status == "failed" else None
+        record["failures"] = [failure] if status == "failed" else []
+        record["recovery"] = self.recovery(run_id)
+        if status == "completed":
+            record["recovery"].update(
+                eligible=False, reason_code="already_completed", message="This request is already complete.",
+            )
+        self.steps[run_id] = [
+            {"step_id": "read", "step_index": 0, "status": "completed", "summary": "Read saved reports",
+             "reused": bool(record["retry_of_run_id"]), "checkpoint_available": True},
+            {"step_id": "research", "step_index": 1, "status": status, "summary": "",
+             "failure": record["failure"]},
+            {"step_id": "answer", "step_index": 2,
+             "status": "completed" if status == "completed" else "skipped", "summary": ""},
+        ]
+        content = "Comparison from saved reports and the recovered agent." if status == "completed" else (
+            "This run was stopped. Available partial results were kept." if status == "cancelled" else FAILURE)
+        metadata = {"orchestration": {
+            key: record[key] for key in ("run_id", "turn_id", "attempt_index", "retry_of_run_id",
+                                        "outcome", "failure", "failures", "recovery",
+                                        "finalization_status", "message_saved") if key in record
+        }}
+        message_id = f"assistant-{run_id}"
+        record["assistant_message_id"] = message_id
+        message = {
+            "id": message_id, "conversation_id": CONVERSATION, "role": "assistant", "content": content,
+            "metadata": metadata, "model_deployment_name": "original-model",
+            "hybrid_citations": [{"document_id": "doc-a", "title": "Saved Report A"}],
+        }
+        self.messages = [message for message in self.messages if message["id"] != message_id] + [message]
+        return {
+            **metadata["orchestration"], "status": status, "done": True, "type": "orchestration_done",
+            "message_id": message_id, "user_message_id": "user-original", "full_content": content,
+            "metadata": metadata, "model_deployment_name": "original-model",
+            "hybrid_citations": message["hybrid_citations"],
+        }
+
+    def begin_finalization(self, run_id, status):
+        self.finish(run_id, status)
+        record = self.records[run_id]
+        self.messages = [message for message in self.messages if message["id"] != record["assistant_message_id"]]
+        record.update(assistant_message_id=None, finalization_status="pending")
+        record.pop("message_saved", None)
+        record["recovery"].update(
+            eligible=False, reason_code="execution_live",
+            message="This attempt is still running. Wait for it to finish or stop it.",
+        )
+
+    @staticmethod
+    def stream(route, events):
+        route.fulfill(content_type="text/event-stream",
+                      body="".join(f"data: {json.dumps(event)}\n\n" for event in events))
+
+    def handle(self, route):
+        request = route.request
+        path = urlsplit(request.url).path
+        body = request.post_data_json if request.post_data else None
+        self.requests.append({"path": path, "method": request.method, "body": body})
+        if request.method == "GET" and path in self.assets:
+            route.fulfill(path=str(self.assets[path]))
+            return
+        if path == "/favicon.ico":
+            route.fulfill(status=204)
+            return
+        if path == editor_tests.RUN:
+            record = self.records[body["run_id"]]
+            if record["retry_of_run_id"]:
+                assert "edits" not in body, "Recovery must execute the immutable saved plan."
+                assert body.get("expected_version") == record["plan"]["edit_version"], (
+                    "Recovery must use the new child's approval version, not the source recovery token."
+                )
+            if self.stream_mode == "reject" and record["retry_of_run_id"]:
+                route.fulfill(status=409, json={"code": "recovery_unavailable"})
+                return
+            record.update(status="running", started_at="2026-09-08T12:00:30Z")
+            if self.stream_mode == "transport":
+                self.stream(route, [{"type": "content", "content": "Partial result before disconnect."}])
+            else:
+                status = "completed" if record["retry_of_run_id"] else "failed"
+                event = self.finish(body["run_id"], status)
+                events = [{"type": "orchestration_step", **step} for step in self.steps[body["run_id"]]]
+                self.stream(route, events + [event])
+            return
+        if path.endswith("/retry"):
+            run_id = path.split("/")[-2]
+            if self.prepare_mode == "confirmation":
+                self.records[run_id]["recovery"]["requires_confirmation"] = True
+                route.fulfill(status=409, json={
+                    "code": "confirmation_required", "recovery": self.records[run_id]["recovery"],
+                })
+                return
+            if self.prepare_mode == "conflict":
+                self.records[run_id]["recovery"].update(eligible=False, current_run_id="other-attempt")
+                route.fulfill(status=409, json={"code": "recovery_changed", "current_run_id": "other-attempt"})
+                return
+            if body["submission_id"] in self.preparations:
+                assert self.preparations[body["submission_id"]][0] == body
+                route.fulfill(json={"run": self.preparations[body["submission_id"]][1]})
+                return
+            assert body["confirm_external_effects"], "Uncertain effects require explicit consent."
+            child_plan = copy.deepcopy(self.records[run_id]["plan"])
+            child_plan.update(
+                run_id="retry-attempt", plan_id="retry-plan", status="awaiting_approval",
+                edit_version="retry-plan-version",
+            )
+            child_plan["approval"] = {"mode": "manual", "timeout_seconds": 0, "state": "pending"}
+            child = self.add_record(child_plan, 2, run_id)
+            self.preparations[body["submission_id"]] = (body, copy.deepcopy(child))
+            self.records[run_id].update(latest_attempt_run_id=child["run_id"])
+            self.records[run_id]["recovery"].update(eligible=False, current_run_id=child["run_id"])
+            if self.prepare_mode == "lost":
+                route.abort()
+            elif self.prepare_mode == "delayed":
+                self.waiting.append(lambda: route.fulfill(json={"run": child}))
+            else:
+                route.fulfill(json={"run": child})
+            return
+        if path.startswith("/api/v2/orchestration/cancel/"):
+            self.finish(path.rsplit("/", 1)[-1], "cancelled")
+            route.fulfill(json={"cancelled": True})
+            return
+        if path == editor_tests.RUNS:
+            route.fulfill(json={"runs": list(self.records.values())})
+            return
+        if path.startswith(editor_tests.RUNS + "/"):
+            run_id = path.split("/")[5]
+            if path.endswith("/steps"):
+                route.fulfill(json={"steps": self.steps.get(run_id, [])})
+            elif run_id in self.records:
+                route.fulfill(json={"run": self.records[run_id]})
+            else:
+                route.fulfill(status=404, json={"code": "not_found"})
+            return
+        if path in ("/api/get_messages", "/api/v2/chat/messages"):
+            route.fulfill(json={"messages": self.messages})
+            return
+        self.errors.append(f"{request.method} {path}")
+        route.fulfill(status=404, json={"error": "Unexpected test request"})
+
+    def calls(self, suffix):
+        return [request for request in self.requests if request["path"].endswith(suffix)]
+
+    def release(self):
+        waiting, self.waiting = self.waiting, []
+        for callback in waiting:
+            callback()
+
+
+@pytest.fixture
+def recovery_ui(editor_browser, editor_assets):
+    context = editor_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+    api = RecoveryApi(editor_assets)
+    page.route("**/*", api.handle)
+    page.on("pageerror", lambda error: api.errors.append(str(error)))
+    try:
+        yield page, api
+    finally:
+        api.release()
+        context.close()
+        assert not api.errors, api.errors
+
+
+def mount_recovery(page, api, *, saved=False):
+    page.goto(editor_tests.ORIGIN + editor_tests.HARNESS)
+    page.wait_for_function("() => Boolean(window.OrchHarness)")
+    for url in api.assets:
+        if url.endswith(".css"):
+            page.add_style_tag(url=editor_tests.ORIGIN + url)
+    page.evaluate(
+        """(spec) => {
+            const H = window.OrchHarness;
+            H.reset();
+            H.stores.bootstrap.useBootstrapStore.setState({ data: {
+                version: '0.261.105', settings: {}, branding: { app_title: 'SimpleChat' },
+                features: { enable_chat_orchestration: true },
+                user: { id: 'editor-tester', display_name: 'Tester' },
+                scope: { groups: [], public_workspaces: [] },
+                orchestration: { enabled: true, capabilities: [] },
+                catalogs: { models: [], agents: [], prompts: [] },
+            } });
+            H.stores.chat.useChatStore.setState({
+                activeConversationId: spec.conversation, activeConversationKind: 'personal',
+                messagesLoading: false, streaming: false, streamingContent: '', thoughts: [],
+                streamError: null, messages: spec.messages, conversations: [],
+            });
+            if (!spec.saved) {
+                const S = H.stores.orchestration.useOrchestrationStore.getState();
+                S.setPlan(spec.conversation, spec.turn, spec.plan);
+                S.setActiveTurn(spec.conversation, spec.turn);
+            }
+            H.mount('mount-a', 'PlanEditorExperience', {}, { strictMode: true });
+        }""",
+        {"plan": api.plan, "messages": api.messages, "conversation": api.plan["conversation_id"],
+         "turn": api.plan["turn_id"], "saved": saved},
+    )
+    if saved:
+        page.evaluate("(id) => window.OrchHarness.resume.resumeOrchestrationForConversation(id)", api.plan["conversation_id"])
+
+
+def start_failure(page, api):
+    mount_recovery(page, api)
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text(FAILURE, exact=True).first).to_be_visible()
+    expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+
+
+def main_state(page):
+    return page.evaluate("""() => {
+        const H = window.OrchHarness;
+        return { messages: H.stores.chat.useChatStore.getState().messages,
+            history: H.stores.orchestration.useOrchestrationStore.getState().history,
+            inFlight: H.stores.orchestration.useOrchestrationStore.getState().inFlight };
+    }""")
+
+
+@pytest.mark.parametrize("edit_version", [None, "saved-plan-edit"])
+def test_failure_persists_in_main_and_drawer_and_confirmed_retry_reuses_progress(recovery_ui, edit_version):
+    page, api = recovery_ui
+    start_failure(page, api)
+    if edit_version:
+        api.records[api.plan["run_id"]]["plan"]["edit_version"] = edit_version
+    assert main_state(page)["history"][CONVERSATION][0]["status"] == "failed"
+    failed_message = main_state(page)["messages"][-1]
+    assert failed_message["metadata"]["orchestration"]["outcome"] == "failed"
+    assert failed_message["hybrid_citations"][0]["document_id"] == "doc-a"
+    page.get_by_role("button", name="Review saved attempt").first.click()
+    drawer = page.get_by_role("complementary", name="Review drawer")
+    expect(drawer.get_by_text(FAILURE, exact=True)).to_be_visible()
+    expect(drawer.locator("p").filter(has_text="Reuse saved results:")).to_contain_text("Read quarterly reports")
+    drawer.get_by_role("button", name="Retry from failed step").click()
+    dialog = page.get_by_role("dialog", name="Retry this failed step?")
+    expect(dialog).to_be_visible()
+    expect(dialog.get_by_text("Previously completed plan steps", exact=False)).to_be_visible()
+    dialog.get_by_role("button", name="Cancel", exact=True).click()
+    assert not api.calls("/retry")
+    drawer.get_by_role("button", name="Retry from failed step").click()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    expect(page.get_by_text("Comparison from saved reports and the recovered agent.", exact=True)).to_be_visible()
+    expect(drawer.get_by_text("Reused saved result", exact=True)).to_be_visible()
+    assert len(api.calls("/retry")) == 1
+    assert [entry["body"]["run_id"] for entry in api.calls("/run")] == [api.plan["run_id"], "retry-attempt"]
+    assert api.calls("/run")[1]["body"]["expected_version"] == "retry-plan-version"
+    state = main_state(page)
+    assert len([message for message in state["messages"] if message["role"] == "user"]) == 1
+    assert len([message for message in state["messages"] if message["role"] == "assistant"]) == 2
+    assert state["messages"][-1]["model_deployment_name"] == "original-model"
+
+
+def test_reload_keeps_failure_without_automatic_retry_and_message_retry_is_not_plain_chat(recovery_ui):
+    page, api = recovery_ui
+    api.finish(api.plan["run_id"])
+    api.plan["approval"]["mode"] = "auto"
+    mount_recovery(page, api, saved=True)
+    expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    assert not api.calls("/run") and not api.calls("/retry")
+    page.get_by_role("button", name="Review orchestration recovery").click(force=True)
+    expect(page.get_by_role("complementary", name="Review drawer")).to_be_visible()
+    assert not any("/api/message/" in request["path"] for request in api.requests)
+
+
+def test_duplicate_confirmation_click_and_context_change_never_run_wrong_turn(recovery_ui):
+    page, api = recovery_ui
+    start_failure(page, api)
+    api.prepare_mode = "delayed"
+    page.get_by_role("button", name="Retry from failed step").click()
+    dialog = page.get_by_role("dialog")
+    with page.expect_request("**/retry"):
+        dialog.get_by_role("button", name="Confirm retry").dblclick()
+    expect(dialog.get_by_role("button", name="Confirm retry")).to_be_disabled()
+    page.evaluate("""() => window.OrchHarness.stores.chat.useChatStore.setState({
+        activeConversationId: 'different-conversation'
+    })""")
+    api.release()
+    page.wait_for_function("""() => !window.OrchHarness.stores.orchestration.useOrchestrationStore
+        .getState().runRecovery['recovery-chat-run-0'].busy""")
+    assert len(api.calls("/retry")) == 1
+    assert len(api.calls("/run")) == 1
+    assert len([message for message in main_state(page)["messages"] if message["role"] == "user"]) == 1
+
+
+@pytest.mark.parametrize("mode", ["conflict", "lost"])
+def test_recovery_conflict_and_lost_preparation_keep_previous_failure(recovery_ui, mode):
+    page, api = recovery_ui
+    start_failure(page, api)
+    api.prepare_mode = mode
+    page.get_by_role("button", name="Retry from failed step").click()
+    with page.expect_request("**/retry"):
+        page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    expect(page.get_by_role("alert").filter(has_text="Recovery").first).to_be_visible()
+    assert len(api.calls("/run")) == 1
+    assert main_state(page)["messages"][-1]["content"] == FAILURE
+    if mode == "conflict":
+        expect(page.get_by_role("button", name="View current attempt").first).to_be_visible()
+    else:
+        api.prepare_mode = "success"
+        page.get_by_role("button", name="Retry from failed step").click()
+        expect(page.get_by_text("Comparison from saved reports and the recovered agent.", exact=True)).to_be_visible()
+        assert api.calls("/retry")[0]["body"] == api.calls("/retry")[1]["body"]
+        assert len(api.preparations) == 1
+
+
+def test_transport_loss_is_unknown_until_explicit_stop_calls_backend(recovery_ui):
+    page, api = recovery_ui
+    api.stream_mode = "transport"
+    mount_recovery(page, api)
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+    expect(page.get_by_role("button", name="Retry from failed step")).to_have_count(0)
+    assert not api.calls("/retry")
+    assert not any("/cancel/" in request["path"] for request in api.requests)
+    assert not main_state(page)["history"].get(CONVERSATION)
+    page.get_by_role("button", name="Stop execution").first.click()
+    expect(page.get_by_text("This attempt was stopped", exact=False).first).to_be_visible()
+    assert len([request for request in api.requests if "/cancel/" in request["path"]]) == 1
+    assert main_state(page)["history"][CONVERSATION][0]["status"] == "cancelled"
+
+
+def test_legacy_history_explains_cannot_resume_without_inventing_reason(recovery_ui):
+    page, api = recovery_ui
+    api.finish(api.plan["run_id"], "cancelled")
+    record = api.records[api.plan["run_id"]]
+    for key in ("recovery", "outcome", "failure", "failures"):
+        record.pop(key, None)
+    api.messages = api.messages[:1]
+    mount_recovery(page, api, saved=True)
+    expect(page.get_by_text("This historical attempt has no verified recovery checkpoint.", exact=False)).to_be_visible()
+    expect(page.get_by_role("button", name="Retry from failed step")).to_have_count(0)
+    assert not api.calls("/run") and not api.calls("/retry")
+
+
+def test_server_confirmation_required_is_a_gate_not_an_automatic_retry(recovery_ui):
+    page, api = recovery_ui
+    api.finish(api.plan["run_id"])
+    api.records[api.plan["run_id"]]["recovery"]["requires_confirmation"] = False
+    api.prepare_mode = "confirmation"
+    mount_recovery(page, api, saved=True)
+    page.get_by_role("button", name="Retry from failed step").click()
+    dialog = page.get_by_role("dialog", name="Retry this failed step?")
+    expect(dialog).to_be_visible()
+    assert len(api.calls("/retry")) == 1
+    assert api.calls("/retry")[0]["body"]["confirm_external_effects"] is False
+    assert not api.preparations and not api.calls("/run")
+    dialog.get_by_role("button", name="Cancel", exact=True).click()
+    assert not api.preparations
+
+
+def test_transport_terminal_reconciliation_keeps_saved_failure_and_no_stop(recovery_ui):
+    page, api = recovery_ui
+    api.stream_mode = "transport"
+    mount_recovery(page, api)
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+    api.finish(api.plan["run_id"])
+    page.get_by_role("button", name="Check saved status").first.click()
+    expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    assert main_state(page)["history"][CONVERSATION][0]["status"] == "failed"
+    assert main_state(page)["messages"][-1]["id"] == f"assistant-{api.plan['run_id']}"
+    assert not any("/cancel/" in request["path"] for request in api.requests)
+    assert not api.calls("/retry")
+
+
+@pytest.mark.parametrize("pending_contract", ["explicit", "lease-only"])
+@pytest.mark.parametrize("status", ["failed", "completed", "cancelled"])
+def test_terminal_status_waits_for_final_publication_after_transport_loss(recovery_ui, status, pending_contract):
+    page, api = recovery_ui
+    api.stream_mode = "transport"
+    page.clock.install()
+    mount_recovery(page, api)
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+
+    run_id = api.plan["run_id"]
+    api.begin_finalization(run_id, status)
+    if pending_contract == "lease-only":
+        api.records[run_id].pop("finalization_status")
+    page.get_by_role("button", name="Check saved status").first.click()
+    try:
+        expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+    except AssertionError as error:
+        raise AssertionError({
+            "state": main_state(page),
+            "recovery": page.evaluate("""() => window.OrchHarness.stores.orchestration
+                .useOrchestrationStore.getState().runRecovery"""),
+            "visible": page.locator("body").inner_text(),
+        }) from error
+    expect(page.get_by_text("The server is saving the final response.", exact=False).first).to_be_visible()
+    assert run_id in main_state(page)["inFlight"]
+    assert not main_state(page)["history"].get(CONVERSATION)
+    expect(page.get_by_text("message was not saved", exact=False)).to_have_count(0)
+    expect(page.get_by_role("button", name="Retry from failed step")).to_have_count(0)
+    page.evaluate("""(record) => {
+        const S = window.OrchHarness.stores.orchestration.useOrchestrationStore;
+        S.setState({ inFlight: { ...S.getState().inFlight,
+            [record.run_id]: { ...S.getState().inFlight[record.run_id], resumed: true } } });
+        S.getState().hydrateConversationRuns(record.conversation_id, [record]);
+    }""", api.records[run_id])
+    assert run_id in main_state(page)["inFlight"]
+
+    api.finish(run_id, status)
+    page.clock.fast_forward(5001)
+    page.wait_for_function("""(id) => window.OrchHarness.stores.chat.useChatStore
+        .getState().messages.some(message => message.id === id)""", arg=f"assistant-{run_id}")
+    assert not main_state(page)["inFlight"]
+    assert main_state(page)["history"][CONVERSATION][0]["status"] == status
+    if status == "failed":
+        expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    assert len(api.calls("/run")) == 1
+    assert not api.calls("/retry")
+    assert not any("/cancel/" in request["path"] for request in api.requests)
+
+
+@pytest.mark.parametrize("status", ["failed", "completed", "cancelled"])
+def test_reload_keeps_polling_until_terminal_publication_is_saved(recovery_ui, status):
+    page, api = recovery_ui
+    run_id = api.plan["run_id"]
+    api.records[run_id]["started_at"] = "2026-09-08T12:00:30Z"
+    api.begin_finalization(run_id, status)
+    page.clock.install()
+    mount_recovery(page, api, saved=True)
+    expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+    assert run_id in main_state(page)["inFlight"]
+    expect(page.get_by_role("button", name="Retry from failed step")).to_have_count(0)
+
+    api.finish(run_id, status)
+    page.clock.fast_forward(5001)
+    page.wait_for_function("""(id) => window.OrchHarness.stores.chat.useChatStore
+        .getState().messages.some(message => message.id === id)""", arg=f"assistant-{run_id}")
+    assert not main_state(page)["inFlight"]
+    assert not api.calls("/run") and not api.calls("/retry")
+    assert not any("/cancel/" in request["path"] for request in api.requests)
+
+
+def test_expired_publication_reports_uncertainty_instead_of_an_unsaved_claim(recovery_ui):
+    page, api = recovery_ui
+    api.stream_mode = "transport"
+    mount_recovery(page, api)
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("Checking execution status", exact=False).first).to_be_visible()
+    run_id = api.plan["run_id"]
+    api.begin_finalization(run_id, "failed")
+    api.records[run_id]["finalization_status"] = "interrupted"
+    api.records[run_id]["recovery"] = api.recovery(run_id)
+    page.get_by_role("button", name="Check saved status").first.click()
+    expect(page.get_by_text("before a final conversation message could be confirmed", exact=False).first).to_be_visible()
+    expect(page.get_by_text("message was not saved", exact=False)).to_have_count(0)
+    assert not main_state(page)["inFlight"]
+    assert not api.calls("/retry")
+
+
+def test_failure_text_is_inert_and_confirmation_is_keyboard_accessible_on_mobile(recovery_ui):
+    page, api = recovery_ui
+    api.finish(api.plan["run_id"])
+    sentinel = '<img src=x onerror="window.recoveryExecuted=true">'
+    api.records[api.plan["run_id"]]["failure"]["message"] = sentinel
+    page.set_viewport_size({"width": 390, "height": 844})
+    mount_recovery(page, api, saved=True)
+    expect(page.get_by_text(sentinel, exact=True)).to_be_visible()
+    expect(page.locator('[onerror]')).to_have_count(0)
+    assert page.evaluate("window.recoveryExecuted") is None
+    retry = page.get_by_role("button", name="Retry from failed step")
+    retry.focus()
+    page.keyboard.press("Enter")
+    dialog = page.get_by_role("dialog", name="Retry this failed step?")
+    expect(dialog).to_be_visible()
+    assert dialog.evaluate("(node) => node.contains(document.activeElement)")
+    page.keyboard.press("Escape")
+    expect(dialog).to_have_count(0)
+    assert not api.calls("/retry")
+
+
+@pytest.mark.parametrize("edit_version", [None, "saved-plan-edit"])
+def test_prepared_child_after_navigation_requires_manual_run_even_after_reload(recovery_ui, edit_version):
+    page, api = recovery_ui
+    start_failure(page, api)
+    if edit_version:
+        api.records[api.plan["run_id"]]["plan"]["edit_version"] = edit_version
+    api.prepare_mode = "delayed"
+    page.get_by_role("button", name="Retry from failed step").click()
+    with page.expect_request("**/retry"):
+        page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    page.evaluate("""() => window.OrchHarness.stores.chat.useChatStore.setState({
+        activeConversationId: 'different-conversation'
+    })""")
+    api.release()
+    page.wait_for_function("""() => !window.OrchHarness.stores.orchestration.useOrchestrationStore
+        .getState().runRecovery['recovery-chat-run-0'].busy""")
+    mount_recovery(page, api, saved=True)
+    expect(page.get_by_role("button", name="View current attempt").first).to_be_visible()
+    assert len(api.calls("/run")) == 1
+    page.get_by_role("button", name="View current attempt").first.click()
+    drawer = page.get_by_role("complementary", name="Review drawer")
+    drawer.get_by_role("button", name="Run prepared retry").click()
+    expect(page.get_by_text("Comparison from saved reports and the recovered agent.", exact=True)).to_be_visible()
+    assert len(api.calls("/retry")) == 1
+    assert len(api.calls("/run")) == 2
+    assert api.calls("/run")[-1]["body"]["expected_version"] == "retry-plan-version"
+
+
+def test_prepared_run_rejection_reports_error_without_false_success_or_polling(recovery_ui):
+    page, api = recovery_ui
+    start_failure(page, api)
+    api.stream_mode = "reject"
+    page.get_by_role("button", name="Retry from failed step").click()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    expect(page.get_by_text("The saved attempt was not started.", exact=False).first).to_be_visible()
+    state = main_state(page)
+    assert not state["inFlight"]
+    assert state["history"][CONVERSATION][0]["status"] == "failed"
+    assert state["messages"][-1]["content"] == FAILURE

--- a/ui_tests/test_v2_orchestration_recovery_backend.py
+++ b/ui_tests/test_v2_orchestration_recovery_backend.py
@@ -1,0 +1,295 @@
+# test_v2_orchestration_recovery_backend.py
+"""
+Browser-to-Flask checkpoint recovery regressions.
+Version: 0.261.105
+Implemented in: 0.261.105
+
+Real orchestration routes, executor, durable checkpoint codec, conditional attempts,
+and message persistence run in the shared backend fixture. Only Azure/model/service
+boundaries are deterministic. The real React UI uses the local/Azure Playwright harness.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+
+import pytest
+from azure.core.exceptions import AzureError
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError, expect
+
+import test_v2_orchestration_plan_editor as editor_tests
+import test_v2_orchestration_recovery as recovery_tests
+from test_v2_orchestration_plan_editor import (  # noqa: F401
+    connect_options,
+    editor_assets,
+    editor_browser,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+# The shared fixture lives outside the UI test import directory.
+from test_support.orchestration_recovery import RecoveryFixture  # noqa: E402
+
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.fixture
+def integrated_recovery(editor_browser, editor_assets):
+    with RecoveryFixture() as backend:
+        plan = backend.plan_attempt()
+        record = backend.detail(plan["run_id"])
+        context = editor_browser.new_context(viewport={"width": 1440, "height": 900})
+        page = context.new_page()
+        requests = []
+        errors = []
+        options = {"lose_terminal": False, "hold_finalization": False, "pending_detail": None}
+
+        def forward(route):
+            request = route.request
+            url = urlsplit(request.url)
+            if f"{url.scheme}://{url.netloc}" != editor_tests.ORIGIN:
+                errors.append(f"Unexpected browser origin: {url.netloc}")
+                route.abort()
+                return
+            if request.method == "GET" and url.path in editor_assets:
+                route.fulfill(path=str(editor_assets[url.path]))
+                return
+            if url.path == "/favicon.ico":
+                route.fulfill(status=204)
+                return
+            if url.path == "/api/get_messages":
+                route.fulfill(json={"messages": [
+                    row for row in backend.messages.items.values() if row.get("role") in ("user", "assistant")
+                ]})
+                return
+            if not url.path.startswith("/api/v2/orchestration/"):
+                errors.append(f"Unexpected browser request: {request.method} {url.path}")
+                route.abort()
+                return
+            response = backend.client.open(
+                url.path + (f"?{url.query}" if url.query else ""),
+                method=request.method, data=request.post_data,
+                content_type=request.headers.get("content-type"), buffered=True,
+            )
+            requests.append({
+                "path": url.path, "status": response.status_code,
+                "body": request.post_data_json if request.post_data else None,
+            })
+            content = response.get_data(as_text=True)
+            pending = options["pending_detail"]
+            if (options["hold_finalization"] and pending and request.method == "GET"
+                    and url.path == f"{editor_tests.RUNS}/{pending['run_id']}"):
+                # Replay the actual projection captured before the message batch committed.
+                content = json.dumps({"run": pending})
+            assert "SECRET_SENTINEL" not in content
+            assert "private.test" not in content
+            if options["lose_terminal"] and url.path == editor_tests.RUN:
+                content = 'data: {"type":"thought","content":"Execution started"}\n\n'
+            route.fulfill(status=response.status_code, content_type=response.content_type, body=content)
+
+        page.route("**/*", forward)
+        page.on("pageerror", lambda error: errors.append(str(error)))
+        mounted = SimpleNamespace(
+            assets=editor_assets, plan=plan,
+            messages=[{
+                "id": record["user_message_id"], "conversation_id": "conv1", "role": "user",
+                "content": record["user_message"], "metadata": {"orchestration_turn_id": record["turn_id"]},
+            }],
+        )
+        try:
+            recovery_tests.mount_recovery(page, mounted)
+            yield page, backend, requests, mounted, options
+        finally:
+            context.close()
+            assert not errors, errors
+
+
+def test_real_failed_agent_resume_reuses_checkpoints_and_survives_reload(integrated_recovery):
+    page, backend, requests, mounted, _options = integrated_recovery
+    initial_user_count = sum(row.get("role") == "user" for row in backend.messages.items.values())
+    page.get_by_role("button", name="Approve and run the plan").click()
+    retry = page.get_by_role("button", name="Retry from failed step")
+    expect(retry.first).to_be_enabled()
+    record = backend.detail(mounted.plan["run_id"])
+    assert backend.calls == ["a", "b"]
+    assert record["outcome"] == "partial"
+    expect(page.get_by_text(record["failure"]["message"], exact=True).first).to_be_visible()
+    assert recovery_tests.main_state(page)["messages"][-1]["metadata"]["orchestration"]["outcome"] == "partial"
+    page.get_by_role("button", name="Review saved attempt").first.click()
+    drawer = page.get_by_role("complementary", name="Review drawer")
+    expect(drawer.get_by_text(record["failure"]["message"], exact=True).first).to_be_visible()
+    drawer.get_by_role("button", name="Retry from failed step").click()
+    page.get_by_role("dialog").get_by_role("button", name="Cancel", exact=True).click()
+    assert not any(request["path"].endswith("/retry") for request in requests)
+    assert backend.calls == ["a", "b"]
+
+    backend.fail_b = False
+    drawer.get_by_role("button", name="Retry from failed step").click()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    try:
+        page.wait_for_function("""() => window.OrchHarness.stores.chat.useChatStore.getState().messages.some(
+            message => message.metadata?.orchestration?.attempt_index === 2
+                && message.metadata.orchestration.outcome === 'completed')""")
+    except PlaywrightTimeoutError as error:
+        raise AssertionError({
+            "requests": requests, "calls": backend.calls, "visible": page.locator("body").inner_text(),
+        }) from error
+    expect(drawer.get_by_text("Reused saved result", exact=True).first).to_be_visible()
+    assert backend.calls == ["a", "b", "b", "c"]
+    assert sum(row.get("role") == "user" for row in backend.messages.items.values()) == initial_user_count
+    assert len([request for request in requests if request["path"].endswith("/retry")]) == 1
+    assert len([request for request in requests if request["path"] == editor_tests.RUN]) == 2
+    assert "Saved findings a" in json.dumps(backend.model.calls[-1])
+    attempts = [message for message in recovery_tests.main_state(page)["messages"]
+                if message.get("metadata", {}).get("orchestration", {}).get("attempt_index")]
+    assert len(attempts) == 2
+    assert attempts[0]["id"] == record["assistant_message_id"]
+    assert attempts[1]["metadata"]["orchestration"]["retry_of_run_id"] == record["run_id"]
+
+    mounted.messages = [
+        row for row in backend.messages.items.values() if row.get("role") in ("user", "assistant")
+    ]
+    recovery_tests.mount_recovery(page, mounted, saved=True)
+    expect(page.get_by_role("button", name="View current attempt").first).to_be_visible()
+    page.get_by_role("button", name="View current attempt").first.click()
+    try:
+        expect(page.get_by_role("complementary", name="Review drawer")
+               .get_by_text("Reused saved result", exact=True).first).to_be_visible()
+    except AssertionError as error:
+        raise AssertionError({"requests": requests[-10:], "visible": page.locator("body").inner_text()}) from error
+    assert backend.calls == ["a", "b", "b", "c"]
+    assert len([request for request in requests if request["path"] == editor_tests.RUN]) == 2
+
+
+def test_edited_plan_resumes_without_reusing_its_approval_version(integrated_recovery):
+    page, backend, requests, mounted, _options = integrated_recovery
+    run_id = mounted.plan["run_id"]
+    response = backend.client.post(
+        f"/api/v2/orchestration/runs/{run_id}/edit",
+        json={"conversation_id": "conv1", "plan_id": mounted.plan["plan_id"]},
+    )
+    assert response.status_code == 200, response.get_data(as_text=True)
+    edited = backend.detail(run_id)["plan"]
+    assert edited["edit_version"]
+    assert backend.run_attempt(edited).status_code == 200
+    assert backend.calls == ["a", "b"]
+
+    mounted.messages = [
+        row for row in backend.messages.items.values() if row.get("role") in ("user", "assistant")
+    ]
+    recovery_tests.mount_recovery(page, mounted, saved=True)
+    backend.fail_b = False
+    page.get_by_role("button", name="Retry from failed step").first.click()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    page.wait_for_function("""() => window.OrchHarness.stores.chat.useChatStore.getState().messages.some(
+        message => message.metadata?.orchestration?.attempt_index === 2
+            && message.metadata.orchestration.outcome === 'completed')""")
+    assert backend.calls == ["a", "b", "b", "c"]
+    retry_run_requests = [request for request in requests if request["path"] == editor_tests.RUN]
+    assert len(retry_run_requests) == 1
+    assert "edits" not in retry_run_requests[0]["body"]
+    child = backend.detail(retry_run_requests[0]["body"]["run_id"])
+    assert retry_run_requests[0]["body"]["expected_version"] == child["plan"]["edit_version"]
+    assert retry_run_requests[0]["body"]["expected_version"] != edited["edit_version"]
+
+
+@pytest.mark.parametrize("lose_terminal", [False, True])
+def test_real_final_model_failure_stays_visible_even_when_transport_ends(integrated_recovery, lose_terminal):
+    page, backend, requests, mounted, options = integrated_recovery
+    backend.model.answer_error = RuntimeError("PRIVATE_MODEL_SENTINEL https://provider.internal/error")
+    options["lose_terminal"] = lose_terminal
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    record = backend.detail(mounted.plan["run_id"])
+    expect(page.get_by_text(record["failure"]["message"], exact=True).first).to_be_visible()
+    state = recovery_tests.main_state(page)
+    assert state["history"]["conv1"][0]["status"] == "failed"
+    assert state["messages"][-1]["id"] == record["assistant_message_id"]
+    assert state["messages"][-1]["content"]
+    assert "PRIVATE_MODEL_SENTINEL" not in page.locator("body").inner_text()
+    assert not any("/cancel/" in request["path"] or request["path"].endswith("/retry") for request in requests)
+
+
+@pytest.mark.parametrize("agent_fails", [True, False])
+def test_real_terminal_projection_keeps_browser_polling_until_message_saved(integrated_recovery, agent_fails):
+    page, backend, requests, mounted, options = integrated_recovery
+    backend.fail_b = agent_fails
+    options.update(lose_terminal=True, hold_finalization=True)
+    run_id = mounted.plan["run_id"]
+
+    def capture_pending_publication(*_args):
+        options["pending_detail"] = backend.detail(run_id)
+
+    backend.messages.before_batch = capture_pending_publication
+    page.clock.install()
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("The server is saving the final response.", exact=False).first).to_be_visible()
+    pending = options["pending_detail"]
+    assert pending["status"] == ("failed" if agent_fails else "completed")
+    assert pending["finalization_status"] == "pending"
+    assert not pending["assistant_message_id"]
+    assert pending["recovery"]["reason_code"] == "execution_live"
+    assert run_id in recovery_tests.main_state(page)["inFlight"]
+    expect(page.get_by_text("message was not saved", exact=False)).to_have_count(0)
+    expect(page.get_by_role("button", name="Retry from failed step")).to_have_count(0)
+
+    options["hold_finalization"] = False
+    page.clock.fast_forward(5001)
+    saved = backend.detail(run_id)
+    assert saved["finalization_status"] == "saved"
+    page.wait_for_function("""(id) => window.OrchHarness.stores.chat.useChatStore
+        .getState().messages.some(message => message.id === id)""", arg=saved["assistant_message_id"])
+    assert not recovery_tests.main_state(page)["inFlight"]
+    if agent_fails:
+        expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    assert len([request for request in requests if request["path"] == editor_tests.RUN]) == 1
+    assert not any("/cancel/" in request["path"] or request["path"].endswith("/retry") for request in requests)
+
+
+def test_lost_message_ack_preserves_saved_failure_and_retry(integrated_recovery):
+    page, backend, requests, mounted, _options = integrated_recovery
+
+    def lose_acknowledgement(*_args):
+        backend.messages.after_batch = None
+        raise AzureError("LOST_PUBLICATION_ACK_SENTINEL")
+
+    backend.messages.after_batch = lose_acknowledgement
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_role("button", name="Retry from failed step").first).to_be_enabled()
+    saved = backend.detail(mounted.plan["run_id"])
+    assert saved["finalization_status"] == "saved"
+    assert saved["message_saved"] is True
+    assert recovery_tests.main_state(page)["messages"][-1]["id"] == saved["assistant_message_id"]
+    assert "LOST_PUBLICATION_ACK_SENTINEL" not in page.locator("body").inner_text()
+    backend.fail_b = False
+    page.get_by_role("button", name="Retry from failed step").first.click()
+    page.get_by_role("dialog").get_by_role("button", name="Confirm retry").click()
+    page.wait_for_function("""() => window.OrchHarness.stores.chat.useChatStore.getState().messages.some(
+        message => message.metadata?.orchestration?.attempt_index === 2
+            && message.metadata.orchestration.outcome === 'completed')""")
+    assert backend.calls == ["a", "b", "b", "c"]
+    assert len([request for request in requests if request["path"].endswith("/retry")]) == 1
+
+
+@pytest.mark.parametrize("agent_fails", [True, False])
+def test_message_storage_outage_keeps_safe_terminal_explanation_in_browser(integrated_recovery, agent_fails):
+    page, backend, requests, _mounted, _options = integrated_recovery
+    backend.fail_b = agent_fails
+    def fail_message_save(step, _context, _kwargs):
+        if step["step_id"] == "b":
+            backend.messages.fail_writes = True
+    backend.before_adapter = fail_message_save
+    page.get_by_role("button", name="Approve and run the plan").click()
+    expect(page.get_by_text("This explanation could not be saved to the conversation.", exact=False).first).to_be_visible()
+    state = recovery_tests.main_state(page)
+    assert state["history"]["conv1"][0]["status"] == "failed"
+    assert state["messages"][-1]["content"]
+    assert state["messages"][-1]["metadata"]["orchestration"]["failure"]["code"] == (
+        "step_timeout" if agent_fails else "message_not_saved"
+    )
+    assert not state["inFlight"]
+    assert not any("/cancel/" in request["path"] for request in requests)


### PR DESCRIPTION
## Summary

- Report safe failure, timeout, and partial outcomes in V2 chat and the Run view instead of silently cancelling. Preserve an explanation even when final answer generation fails.
- Add durable step checkpoints and manual linked retry attempts that reuse completed work without replanning. Require confirmation when retrying an agent/action might repeat external effects.
- Reconcile disconnects and final-message publication; protect checkpoint integrity, current authorization, concurrent retries, expired workers, and conversation deletion.
- Update the recovery guides, chat-control reference, feature/fix documentation, and application version to `0.261.105`.

This targets the existing `paullizer-react-v2-ui` integration branch. Recovery is at orchestration-step boundaries, not within an agent's internal tool loop. Legacy runs without checkpoints remain readable but cannot resume. No integration-specific heuristics or automatic full-plan replay are introduced.

## Linked issue

No associated issue.

## Release Notes & Latest Features

- [x] New Feature
- [x] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [ ] Yes
- [x] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped from `0.261.104` to `0.261.105`
- [x] `deployers/version.txt` bump not needed because `deployers/` was not changed

## Testing / validation

- Backend recovery/revision/context/memory/delegation/source-manifest matrix: **243 passed, 125 subtests passed**.
- Combined V2 recovery, real browser-to-Flask recovery, and plan-editor suite: **63 passed**.
- Existing standalone executor, adapter, hydration, citation, route-policy, and V2 approval/card/drawer checks passed.
- V2 typecheck and production build passed. Documentation coverage and quality passed; generated inventory remains current.
- Added crash-boundary regressions for inherited checkpoints across multiple attempts, lost publication acknowledgements, and terminal status arriving before message publication finishes.

```powershell
python -m pytest .\functional_tests\test_orchestration_checkpoint_recovery.py .\functional_tests\test_orchestration_conversation_context_routes.py .\functional_tests\test_orchestration_plan_revision_store.py .\functional_tests\test_orchestration_plan_revision_routes.py .\functional_tests\test_orchestration_memory_context.py .\functional_tests\test_agent_delegation_runtime.py .\functional_tests\test_mixed_source_manifest_contracts.py .\functional_tests\test_orchestration_conversation_context.py -q
python -m pytest .\ui_tests\test_v2_orchestration_recovery.py .\ui_tests\test_v2_orchestration_recovery_backend.py .\ui_tests\test_v2_orchestration_plan_editor.py -q
npm --prefix .\application\v2_ui run typecheck
npm --prefix .\application\v2_ui run build
python .\functional_tests\test_docs_app_surface_coverage.py
python .\functional_tests\test_docs_site_quality.py
```

## Documentation

- [ ] Release notes updated, or not needed — release-note changes were not requested and are deferred
- [x] Feature documentation updated
- [x] Fix documentation updated

New engineering documentation: `docs/explanation/features/ORCHESTRATION_CHECKPOINT_RECOVERY.md` and `docs/explanation/fixes/ORCHESTRATION_ERROR_COMMUNICATION_FIX.md`. Updated the orchestration guide, admin reference, and chat controls.

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`
- [x] Settings sent to non-admin frontends retain the existing sanitized flow; no raw settings payload was added
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included

Private checkpoint payloads are excluded from browser projections. Retry preparation and reuse revalidate ownership, capabilities, context, and sources; uncertain external effects require server-enforced confirmation.