### PR TITLE
Bugfix/disabling allow all in action governance now disables it

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -98,7 +98,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.024"
+VERSION = "0.261.025"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 # Opt-out for deployments where App Service Easy Auth is active but the platform

--- a/application/single_app/functions_governance.py
+++ b/application/single_app/functions_governance.py
@@ -1228,8 +1228,9 @@ def ensure_action_type_access(
         )
 
     if _passes_policy(feature_policy, normalized_user_id, user_group_ids):
-        _set_request_cache_value(decision_key, True)
-        return
+        if not action_type_policies:
+            _set_request_cache_value(decision_key, True)
+            return
 
     if any(_passes_policy(policy, normalized_user_id, user_group_ids) for policy in action_type_policies):
         _set_request_cache_value(decision_key, True)

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.025)**
+
+#### Bug Fixes
+
+*   **Delegated Action-Type Policies Now Override Broad Action Access**
+    *   Fixed a governance gap where an explicit delegated item policy for a personal, group, or global action type could still be bypassed by a broader feature-level allow.
+    *   Action-type governance now treats explicit item policies as authoritative once they exist, so a targeted policy such as `personal_action_type = azure_maps` can block that action type even when the broader action feature remains enabled.
+    *   This resolves cases where action types such as Azure Maps continued to appear in action creation flows after admins saved a delegated item policy intended to block them.
+    *   (Ref: delegated item governance, action-type enforcement, `functions_governance.py`)
+
 ### **(v0.261.023)**
 
 #### New Features


### PR DESCRIPTION
<!-- Thanks for contributing to SimpleChat! Keep this practical and delete sections that truly do not apply. -->

## Summary

- Fixed delegated action-type governance so explicit item policies now override broader feature-level action access once they exist.
- Prevents blocked action types, such as Azure Maps, from still appearing in personal workspace action creation flows after an admin saves a delegated item policy.
- Aligns governance enforcement with the admin policy intent: an explicit targeted policy is now authoritative for that action type.

## Release Notes & Latest Features

- [ ] New Feature
- [x] Bug Fix
- [ ] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [x] Yes
- [ ] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped, or not needed because this is docs-only
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed

## Testing / validation

- `git diff --check origin/Development...HEAD -- application/single_app/config.py application/single_app/functions_governance.py`
- `python -m py_compile application/single_app/config.py application/single_app/functions_governance.py`
- `python scripts/check_broken_access_control.py --base-sha origin/Development --head-sha HEAD application/single_app/functions_governance.py`
- `python scripts/check_xss_sinks.py --base-sha origin/Development --head-sha HEAD application/single_app/functions_governance.py`
- Manual validation: confirmed the personal action-type governance scenario where an explicit policy targeting Azure Maps should remove it from the governed action-type list.

Before change, a delegation item with Allow All disabled and no one granted still allowed all users and groups to access it. 
Policy configured to disable all access to the Personal Action "Azure Maps"
<img width="910" height="1006" alt="image" src="https://github.com/user-attachments/assets/9dff7dd0-b0b7-4334-8383-36f922e9f8a8" />

"Azure Maps" action still available in Personal Workspace:
<img width="720" height="225" alt="image" src="https://github.com/user-attachments/assets/d7711204-4d28-45a2-ae7e-8d9bb6f29313" />
<img width="792" height="742" alt="image" src="https://github.com/user-attachments/assets/3ca6c05d-5afc-4fb7-a412-5ac1f3708f1f" />

After change in this PR, the same policy disabled Azure Maps action
<img width="723" height="1226" alt="image" src="https://github.com/user-attachments/assets/c5238f18-313a-4e16-92a2-aed225785083" />

## Documentation

- [x] Release notes updated, or not needed
- [ ] Feature documentation updated, or not needed
- [ ] Fix documentation updated, or not needed

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()`
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included